### PR TITLE
fix(event): raise MessageLost from sequence gaps

### DIFF
--- a/crates/hiroz-tests/tests/message_lost.rs
+++ b/crates/hiroz-tests/tests/message_lost.rs
@@ -20,9 +20,7 @@ use std::{
 
 use common::{TestRouter, create_hiroz_context_with_endpoint};
 use hiroz::{
-    Builder, GidArray, TypeHash,
-    attachment::Attachment,
-    event::ZenohEventType,
+    Builder, GidArray, TypeHash, attachment::Attachment, event::ZenohEventType,
     ros_msg::MessageTypeInfo,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/hiroz-tests/tests/message_lost.rs
+++ b/crates/hiroz-tests/tests/message_lost.rs
@@ -1,0 +1,187 @@
+//! `RMW_EVENT_MESSAGE_LOST` must actually be raised by a live subscriber.
+//!
+//! `event.rs`'s unit tests pin `MessageLossTracker`'s arithmetic. They say
+//! nothing about whether anything *calls* it: delete the `observe_loss(..)` line
+//! from the subscriber's receive path and every one of them still passes. This
+//! file is the detector for that wiring.
+//!
+//! Loss is induced deterministically rather than by trying to drop a packet.
+//! The subscriber's own key expression is published to directly, through the
+//! node's zenoh session, with a hand-built [`Attachment`] carrying a chosen
+//! sequence number — so the gap is exact and there is no timing to lose.
+
+mod common;
+
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use common::{TestRouter, create_hiroz_context_with_endpoint};
+use hiroz::{
+    Builder, GidArray, TypeHash,
+    attachment::Attachment,
+    event::ZenohEventType,
+    ros_msg::MessageTypeInfo,
+};
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use zenoh::Wait;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Tick {
+    counter: u64,
+}
+
+impl MessageTypeInfo for Tick {
+    fn type_name() -> &'static str {
+        "test_msgs::msg::dds_::Tick_"
+    }
+    fn type_hash() -> TypeHash {
+        TypeHash::zero()
+    }
+}
+
+impl hiroz::ros_msg::WithTypeInfo for Tick {}
+
+impl hiroz::msg::ZMessage for Tick {
+    type Serdes = hiroz::msg::SerdeCdrSerdes<Tick>;
+}
+
+fn gid(n: u8) -> GidArray {
+    let mut g = [0u8; 16];
+    g[0] = n;
+    g
+}
+
+/// Wait until `total_count` for `MessageLost` stops changing, then return it.
+fn settled_loss_count(sub_events: &Arc<Mutex<hiroz::event::EventsManager>>) -> i32 {
+    let mut last = -1;
+    let mut stable_since = Instant::now();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let now = sub_events
+            .lock()
+            .unwrap()
+            .take_event_status(ZenohEventType::MessageLost)
+            .total_count;
+        if now != last {
+            last = now;
+            stable_since = Instant::now();
+        } else if stable_since.elapsed() >= Duration::from_millis(400) {
+            return now;
+        }
+        assert!(Instant::now() < deadline, "loss count never settled");
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// A gap in a publisher's sequence numbers raises `MessageLost` on the
+/// subscriber that saw it, with the count of samples that never arrived.
+#[test]
+#[serial]
+fn a_sequence_gap_raises_message_lost() {
+    const TOPIC: &str = "/message_lost_gap";
+
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_endpoint(router.endpoint()).expect("context");
+    let node = ctx.create_node("message_lost_node").build().expect("node");
+
+    let received = Arc::new(Mutex::new(Vec::<u64>::new()));
+    let cb_received = received.clone();
+    let sub = node
+        .create_sub::<Tick>(TOPIC)
+        .build_with_callback(move |msg: Tick| {
+            cb_received.lock().unwrap().push(msg.counter);
+        })
+        .expect("subscriber");
+
+    // Publish straight onto the subscriber's own key expression, so the
+    // sequence numbers are ours to choose.
+    let ke = node
+        .keyexpr_format()
+        .topic_key_expr(sub.entity())
+        .expect("topic key expr");
+    let session = node.session();
+    let publisher_gid = gid(42);
+
+    let put = |sn: i64, counter: u64| {
+        let zbuf = <hiroz::msg::SerdeCdrSerdes<Tick> as hiroz::msg::ZSerializer>::serialize_to_zbuf(
+            &Tick { counter },
+        );
+        session
+            .put((*ke).clone(), zenoh::bytes::ZBytes::from(zbuf))
+            .attachment(Attachment::new(sn, publisher_gid))
+            .wait()
+            .expect("put");
+    };
+
+    thread::sleep(Duration::from_millis(300));
+
+    put(0, 0); // baseline — first from this publisher, never counted
+    put(1, 1); // contiguous
+    put(5, 5); // 2, 3 and 4 never arrived
+
+    let lost = settled_loss_count(sub.events_mgr());
+
+    assert_eq!(
+        lost, 3,
+        "expected the three skipped sequence numbers to be reported as lost; \
+         got {lost}. Zero means the receive path never fed the loss tracker"
+    );
+    assert_eq!(
+        received.lock().unwrap().len(),
+        3,
+        "all three published samples should still have been delivered — \
+         detecting loss must not drop anything"
+    );
+}
+
+/// A subscriber that joins late has not "lost" the history it was never sent.
+///
+/// Without the first-sample exemption this reports the publisher's sequence
+/// number as the loss count, so every late joiner looks catastrophically lossy.
+#[test]
+#[serial]
+fn joining_late_reports_no_loss() {
+    const TOPIC: &str = "/message_lost_late_join";
+
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_endpoint(router.endpoint()).expect("context");
+    let node = ctx
+        .create_node("message_lost_late_node")
+        .build()
+        .expect("node");
+
+    let sub = node
+        .create_sub::<Tick>(TOPIC)
+        .build_with_callback(|_msg: Tick| {})
+        .expect("subscriber");
+
+    let ke = node
+        .keyexpr_format()
+        .topic_key_expr(sub.entity())
+        .expect("topic key expr");
+    let session = node.session();
+
+    thread::sleep(Duration::from_millis(300));
+
+    // First sample this subscriber ever sees from this publisher, and it is
+    // already well into the publisher's stream.
+    let zbuf = <hiroz::msg::SerdeCdrSerdes<Tick> as hiroz::msg::ZSerializer>::serialize_to_zbuf(
+        &Tick { counter: 9000 },
+    );
+    session
+        .put((*ke).clone(), zenoh::bytes::ZBytes::from(zbuf))
+        .attachment(Attachment::new(9000, gid(7)))
+        .wait()
+        .expect("put");
+
+    let lost = settled_loss_count(sub.events_mgr());
+
+    assert_eq!(
+        lost, 0,
+        "a late joiner must not be charged for history it was never sent"
+    );
+}

--- a/crates/hiroz-tests/tests/message_lost.rs
+++ b/crates/hiroz-tests/tests/message_lost.rs
@@ -55,6 +55,13 @@ fn gid(n: u8) -> GidArray {
     g
 }
 
+/// A CDR-encoded `Tick`, ready to hand to `Session::put`.
+fn payload(counter: u64) -> zenoh::bytes::ZBytes {
+    use hiroz::msg::ZSerializer;
+    let zbuf = <hiroz::msg::SerdeCdrSerdes<Tick>>::serialize_to_zbuf(&Tick { counter });
+    zenoh::bytes::ZBytes::from(zbuf)
+}
+
 /// Wait until `total_count` for `MessageLost` stops changing, then return it.
 fn settled_loss_count(sub_events: &Arc<Mutex<hiroz::event::EventsManager>>) -> i32 {
     let mut last = -1;
@@ -107,11 +114,8 @@ fn a_sequence_gap_raises_message_lost() {
     let publisher_gid = gid(42);
 
     let put = |sn: i64, counter: u64| {
-        let zbuf = <hiroz::msg::SerdeCdrSerdes<Tick> as hiroz::msg::ZSerializer>::serialize_to_zbuf(
-            &Tick { counter },
-        );
         session
-            .put((*ke).clone(), zenoh::bytes::ZBytes::from(zbuf))
+            .put((*ke).clone(), payload(counter))
             .attachment(Attachment::new(sn, publisher_gid))
             .wait()
             .expect("put");
@@ -169,11 +173,8 @@ fn joining_late_reports_no_loss() {
 
     // First sample this subscriber ever sees from this publisher, and it is
     // already well into the publisher's stream.
-    let zbuf = <hiroz::msg::SerdeCdrSerdes<Tick> as hiroz::msg::ZSerializer>::serialize_to_zbuf(
-        &Tick { counter: 9000 },
-    );
     session
-        .put((*ke).clone(), zenoh::bytes::ZBytes::from(zbuf))
+        .put((*ke).clone(), payload(9000))
         .attachment(Attachment::new(9000, gid(7)))
         .wait()
         .expect("put");

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -445,6 +445,67 @@ pub fn update_shared_event_status(
     update_shared_event_status_with_policy(events_mgr, event_type, change, 0)
 }
 
+/// Detects samples lost **in transit** and raises [`ZenohEventType::MessageLost`].
+///
+/// Every sample carries an [`Attachment`] with the publisher's GID and a
+/// per-publisher sequence number. Holding the last sequence seen from each
+/// publisher makes a gap detectable: receiving `n` when `n - 2` was the last
+/// means one sample never arrived.
+///
+/// [`Attachment`]: crate::attachment::Attachment
+///
+/// # What this does *not* count
+///
+/// A subscriber dropping its own oldest queued sample because the queue is at
+/// its history depth. That sample **arrived** — it updated the last-seen
+/// sequence on the way in — so it produces no gap, and the ROS event does not
+/// claim it. `rmw_zenoh_cpp` draws the line in the same place: its depth-drops
+/// are a debug log, and only sequence gaps raise `MESSAGE_LOST`.
+pub struct MessageLossTracker {
+    events_mgr: Arc<Mutex<EventsManager>>,
+    /// Last sequence number seen per publisher GID.
+    ///
+    /// Its own lock, and never held across the callout below — raising the
+    /// event runs user code, which may re-enter this subscriber.
+    last_seen: Mutex<HashMap<GidArray, i64>>,
+}
+
+impl MessageLossTracker {
+    pub fn new(events_mgr: Arc<Mutex<EventsManager>>) -> Self {
+        Self {
+            events_mgr,
+            last_seen: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record an arrival, raising the event if it skipped past anything.
+    pub fn observe(&self, source_gid: GidArray, sequence_number: i64) {
+        let lost = {
+            let Ok(mut seen) = self.last_seen.lock() else {
+                return;
+            };
+            match seen.insert(source_gid, sequence_number) {
+                // Not the first from this publisher: anything strictly between
+                // the two never arrived. A non-positive difference means a
+                // retransmit, a reorder, or a publisher that restarted its
+                // numbering — none of which is loss, so it reports nothing.
+                Some(previous) => sequence_number.saturating_sub(previous).saturating_sub(1),
+                // First sample from this publisher. There is no baseline to
+                // measure against, and a subscriber that joined late has not
+                // "lost" the history it was never sent.
+                None => 0,
+            }
+        };
+
+        if lost > 0 {
+            // Clamped rather than truncated: the rmw status field is i32, and a
+            // publisher restart can produce an arbitrarily large apparent jump.
+            let lost = lost.min(i64::from(i32::MAX)) as i32;
+            update_shared_event_status(&self.events_mgr, ZenohEventType::MessageLost, lost);
+        }
+    }
+}
+
 /// [`update_shared_event_status`] with a QoS policy kind.
 ///
 /// # Known hazard
@@ -554,6 +615,54 @@ mod tests {
         assert!(!status.changed);
         assert_eq!(status.total_count, 0);
         assert_eq!(status.current_count, 0);
+    }
+
+    /// Drive a tracker through a sequence of arrivals and return the total
+    /// `MessageLost` count it reported.
+    fn losses_for(arrivals: &[(u8, i64)]) -> i32 {
+        let mgr = Arc::new(Mutex::new(EventsManager::new(gid(1))));
+        let tracker = MessageLossTracker::new(mgr.clone());
+        for &(publisher, sn) in arrivals {
+            tracker.observe(gid(publisher), sn);
+        }
+        mgr.lock()
+            .unwrap()
+            .take_event_status(ZenohEventType::MessageLost)
+            .total_count
+    }
+
+    #[test]
+    fn message_loss_is_counted_from_sequence_gaps() {
+        // 0,1,2 contiguous → nothing lost. Then 5 skips 3 and 4.
+        assert_eq!(losses_for(&[(1, 0), (1, 1), (1, 2), (1, 5)]), 2);
+    }
+
+    #[test]
+    fn message_loss_ignores_the_first_sample_from_a_publisher() {
+        // A late joiner's first sample has no baseline. Reporting `sn` as the
+        // loss count would make every subscriber that starts late look lossy.
+        assert_eq!(losses_for(&[(1, 9_000)]), 0);
+    }
+
+    #[test]
+    fn message_loss_is_tracked_per_publisher() {
+        // Interleaved publishers each keep their own baseline; without that,
+        // alternating 0,0,1,1 reads as a gap on every other sample.
+        assert_eq!(losses_for(&[(1, 0), (2, 0), (1, 1), (2, 1)]), 0);
+    }
+
+    #[test]
+    fn message_loss_ignores_reorder_and_republish() {
+        // A non-positive difference is a retransmit, a reorder, or a publisher
+        // that restarted its numbering — none of which is loss.
+        assert_eq!(losses_for(&[(1, 5), (1, 3), (1, 5), (1, 0)]), 0);
+    }
+
+    #[test]
+    fn message_loss_clamps_an_implausible_jump() {
+        // A restarted publisher can present an arbitrarily large apparent gap;
+        // the rmw status field is i32, so it must saturate rather than wrap.
+        assert_eq!(losses_for(&[(1, 0), (1, i64::MAX)]), i32::MAX);
     }
 
     #[test]

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -484,22 +485,42 @@ impl MessageLossTracker {
             let Ok(mut seen) = self.last_seen.lock() else {
                 return;
             };
-            match seen.insert(source_gid, sequence_number) {
-                // Not the first from this publisher: anything strictly between
-                // the two never arrived. A non-positive difference means a
-                // retransmit, a reorder, or a publisher that restarted its
-                // numbering — none of which is loss, so it reports nothing.
-                Some(previous) => sequence_number.saturating_sub(previous).saturating_sub(1),
+            match seen.entry(source_gid) {
                 // First sample from this publisher. There is no baseline to
                 // measure against, and a subscriber that joined late has not
                 // "lost" the history it was never sent.
-                None => 0,
+                Entry::Vacant(slot) => {
+                    slot.insert(sequence_number);
+                    0
+                }
+                Entry::Occupied(mut slot) => {
+                    let high_water = *slot.get();
+                    // The baseline only ever moves **forward**. An arrival at or
+                    // below it is a replay, a retransmit or a reorder — not
+                    // loss — and letting it move the baseline backwards would
+                    // make the *next* ordinary sample look like a gap.
+                    //
+                    // This is a deliberate divergence from `rmw_zenoh_cpp`,
+                    // which uses `std::abs(sn - last)` and rewrites the
+                    // baseline unconditionally. On a `TransientLocal`
+                    // subscriber, history replay delivers older sequence
+                    // numbers as a matter of course, so that shape reports
+                    // phantom loss twice per replayed sample.
+                    if sequence_number <= high_water {
+                        0
+                    } else {
+                        slot.insert(sequence_number);
+                        sequence_number.saturating_sub(high_water).saturating_sub(1)
+                    }
+                }
             }
         };
 
         if lost > 0 {
             // Clamped rather than truncated: the rmw status field is i32, and a
-            // publisher restart can produce an arbitrarily large apparent jump.
+            // publisher that restarts its numbering can present an arbitrarily
+            // large apparent jump. (In ROS a restarted endpoint normally gets a
+            // fresh GID and lands in the vacant arm instead.)
             let lost = lost.min(i64::from(i32::MAX)) as i32;
             update_shared_event_status(&self.events_mgr, ZenohEventType::MessageLost, lost);
         }
@@ -656,6 +677,17 @@ mod tests {
         // A non-positive difference is a retransmit, a reorder, or a publisher
         // that restarted its numbering — none of which is loss.
         assert_eq!(losses_for(&[(1, 5), (1, 3), (1, 5), (1, 0)]), 0);
+    }
+
+    /// A replayed sample must not make the *next* ordinary one look like a gap.
+    ///
+    /// This is the case `rmw_zenoh_cpp` gets wrong: `std::abs(sn - last)` plus
+    /// an unconditional baseline rewrite reports 1 lost for the replay and 2
+    /// more for the sample after it. Every `TransientLocal` subscriber replays
+    /// history, so it is reachable rather than theoretical.
+    #[test]
+    fn message_loss_survives_a_transient_local_replay() {
+        assert_eq!(losses_for(&[(1, 5), (1, 3), (1, 6)]), 0);
     }
 
     #[test]

--- a/crates/hiroz/src/event.rs
+++ b/crates/hiroz/src/event.rs
@@ -697,6 +697,29 @@ mod tests {
         assert_eq!(losses_for(&[(1, 0), (1, i64::MAX)]), i32::MAX);
     }
 
+    /// A publisher that restarts and reuses its GID, but resets its sequence
+    /// counter to something *below* the old high-water mark, has real gaps in
+    /// its new stream silently undercounted as zero until its sequence number
+    /// climbs back past that old mark.
+    ///
+    /// `endpoint_gid` is derived from the zenoh session id plus the entity id,
+    /// not from anything ROS assigns fresh per process, so "a restarted
+    /// endpoint normally gets a fresh GID" does not hold for a deployment
+    /// with a pinned/deterministic session id. This is a known, intentional
+    /// tradeoff of always treating `sn <= high_water` as replay rather than
+    /// loss (see `message_loss_survives_a_transient_local_replay` above,
+    /// which needs exactly that rule to avoid `rmw_zenoh_cpp`'s phantom
+    /// double-count on `TransientLocal` history replay) — pinned here as
+    /// intentional and tracked, not accidental. See circle/hiroz#207.
+    #[test]
+    fn message_loss_undercounts_after_a_same_gid_publisher_restart() {
+        // Baseline established high (100), then the publisher "restarts":
+        // same GID, sequence numbers reset low. `5` skips `2, 3, 4` in the
+        // new stream -- a real 3-sample gap -- but every arrival is `<= 100`,
+        // so the tracker reports zero throughout.
+        assert_eq!(losses_for(&[(1, 100), (1, 1), (1, 5)]), 0);
+    }
+
     #[test]
     fn test_update_event_status_fires_callback() {
         let called = Arc::new(Mutex::new(0i32));

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -1012,6 +1012,25 @@ impl<T: ZMessage, Q, S: ZDeserializer> std::fmt::Debug for ZSub<T, Q, S> {
     }
 }
 
+/// Accessors that do not depend on how the subscriber delivers.
+///
+/// These were on the `ZSub<T, Sample, S>` (queue-mode) impl only, so a callback
+/// subscriber could not reach its own events manager — the handle the rmw layer
+/// needs to install an event callback, and the only way to observe
+/// [`MessageLost`](crate::event::ZenohEventType::MessageLost). Neither field has
+/// anything to do with the queue.
+impl<T, Q, S> ZSub<T, Q, S> {
+    /// The event manager this subscriber raises endpoint events on.
+    pub fn events_mgr(&self) -> &Arc<Mutex<EventsManager>> {
+        &self.events_mgr
+    }
+
+    /// Get a reference to the endpoint entity for this subscriber.
+    pub fn entity(&self) -> &EndpointEntity {
+        &self.entity
+    }
+}
+
 impl<T, S> ZSub<T, Sample, S>
 where
     T: ZMessage,
@@ -1041,15 +1060,6 @@ where
         queue
             .recv_timeout(timeout)
             .ok_or_else(|| crate::error::Error::timeout(timeout))
-    }
-
-    pub fn events_mgr(&self) -> &Arc<Mutex<EventsManager>> {
-        &self.events_mgr
-    }
-
-    /// Get a reference to the endpoint entity for this subscriber.
-    pub fn entity(&self) -> &EndpointEntity {
-        &self.entity
     }
 
     /// Check if there are messages available in the queue

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -10,7 +10,7 @@ use crate::Builder;
 use crate::attachment::{Attachment, GidArray};
 use crate::common::DataHandler;
 use crate::entity::{EndpointEntity, EndpointKind};
-use crate::event::EventsManager;
+use crate::event::{EventsManager, MessageLossTracker};
 use crate::graph::Graph;
 use crate::impl_with_type_info;
 use crate::queue::BoundedQueue;
@@ -35,6 +35,22 @@ const SAMPLE_MISS_HEARTBEAT_PERIOD: Duration = Duration::from_millis(500);
 /// (`Duration::from_millis(u64::MAX)`, not `Duration::MAX`, to avoid any
 /// truncation surprises inside zenoh-ext's internal `as_millis()` paths).
 const TRANSIENT_LOCAL_QUERY_TIMEOUT: Duration = Duration::from_millis(u64::MAX);
+
+/// Feed an arriving sample's attachment to the loss tracker.
+///
+/// A sample whose attachment is missing or undecodable is **ignored, not
+/// counted**. The sequence number is the only thing that makes loss detectable,
+/// and a publisher that does not send one — a plain zenoh peer rather than a
+/// hiroz node — must not be reported as lossy just for being unrecognised.
+fn observe_loss(loss: &MessageLossTracker, sample: &Sample) {
+    let Some(bytes) = sample.attachment() else {
+        return;
+    };
+    let Ok(attachment) = Attachment::try_from(bytes) else {
+        return;
+    };
+    loss.observe(attachment.source_gid, attachment.sequence_number);
+}
 
 fn cache_depth_from_history(history: QosHistory) -> usize {
     // Mirrors rmw_zenoh_cpp's `QoS::best_available_qos` (`qos.cpp:107`):
@@ -802,9 +818,17 @@ where
             key_expr, self.entity.qos
         );
 
+        // Built here rather than at `ZSub` construction: the loss tracker needs
+        // a handle to it, and the tracker is captured by the callback below.
+        let gid = crate::entity::endpoint_gid(&self.entity)
+            .expect("local endpoint always has node identity");
+        let events_mgr = Arc::new(Mutex::new(EventsManager::new(gid)));
+        let loss = Arc::new(MessageLossTracker::new(events_mgr.clone()));
+
         // Wrap handler with encoding validation if expected encoding is set
         let expected_encoding = self.expected_encoding.clone();
         let validated_handler = move |sample: Sample| {
+            observe_loss(&loss, &sample);
             // Validate encoding if expected encoding is set
             if let Some(ref expected) = expected_encoding {
                 let encoding_str = sample.encoding().to_string();
@@ -841,8 +865,6 @@ where
         let sub_builder = apply_transient_local_sub(sub_builder, &self.entity.qos);
         let inner = sub_builder.wait()?;
 
-        let gid = crate::entity::endpoint_gid(&self.entity)
-            .expect("local endpoint always has node identity");
         let lv_ke = self
             .keyexpr_format
             .liveliness_key_expr(&self.entity, &self.session.zid())?;
@@ -859,7 +881,7 @@ where
             _inner: inner,
             _lv_token: lv_token,
             queue,
-            events_mgr: Arc::new(Mutex::new(EventsManager::new(gid))),
+            events_mgr,
             graph: self.graph,
             dyn_schema: self.dyn_schema,
             expected_encoding: self.expected_encoding,

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -1019,7 +1019,7 @@ impl<T: ZMessage, Q, S: ZDeserializer> std::fmt::Debug for ZSub<T, Q, S> {
 /// needs to install an event callback, and the only way to observe
 /// [`MessageLost`](crate::event::ZenohEventType::MessageLost). Neither field has
 /// anything to do with the queue.
-impl<T, Q, S> ZSub<T, Q, S> {
+impl<T: ZMessage, Q, S: ZDeserializer> ZSub<T, Q, S> {
     /// The event manager this subscriber raises endpoint events on.
     pub fn events_mgr(&self) -> &Arc<Mutex<EventsManager>> {
         &self.events_mgr


### PR DESCRIPTION
## Summary

hiroz plumbs `RMW_EVENT_MESSAGE_LOST` fully, but raises it nowhere. A subscriber that registers a callback for it gets one that cannot fire, plus a status that stays zero. In-transit message loss is invisible to every ROS 2 application on hiroz.

This PR adds `MessageLossTracker`: a per-publisher sequence-number baseline on the subscriber. It raises the event when an arrival skips past that baseline.

Fixes #292.

## The defect

What already existed, and the one piece that was missing:

| layer | state before this PR |
|---|---|
| `ZenohEventType::MessageLost` | defined in `event.rs` |
| `rmw_event_type` 3 → `MessageLost` | [mapped](https://github.com/ZettaScaleLabs/hiroz/blob/604b0cd54bbb1165683a26a80ed8c15cbedc0b96/crates/rmw-zenoh-rs/src/rmw.rs#L57-L70), so `rmw_event_type_is_supported` returns **true** |
| `rmw_message_lost_status_t` fill-in on `rmw_take_event` | [present](https://github.com/ZettaScaleLabs/hiroz/blob/604b0cd54bbb1165683a26a80ed8c15cbedc0b96/crates/rmw-zenoh-rs/src/rmw.rs#L886-L892) |
| `Attachment::sequence_number` and `source_gid` on every sample | serialised already |
| **anything that raises the event** | nothing, outside `#[cfg(test)]` |

`ZenohEventType` has 11 variants. Four map to `None` and are honestly declared unsupported: both `LIVELINESS_*` and both `DEADLINE_MISSED`. Four are raised from `rmw.rs`. **Three are declared supported and never raised.**

This PR closes the one where hiroz trails `rmw_zenoh_cpp`. The other two are `SUBSCRIPTION_INCOMPATIBLE_TYPE` and `PUBLISHER_INCOMPATIBLE_TYPE`, tracked as #293, which `rmw_zenoh_cpp` does not raise either.

## What this PR does

| change | where |
|---|---|
| [`MessageLossTracker`](https://github.com/ZettaScaleLabs/hiroz/blob/604b0cd54bbb1165683a26a80ed8c15cbedc0b96/crates/hiroz/src/event.rs#L449-L528) — per-GID baseline, raises `MessageLost` on a forward skip | `crates/hiroz/src/event.rs` |
| [`observe_loss(..)` on the subscriber receive path](https://github.com/ZettaScaleLabs/hiroz/blob/604b0cd54bbb1165683a26a80ed8c15cbedc0b96/crates/hiroz/src/pubsub.rs#L831), inside `build_internal` so every build variant is covered | `crates/hiroz/src/pubsub.rs` |
| `events_mgr()` and `entity()` widened from the queue-mode impl to all `ZSub` variants | `crates/hiroz/src/pubsub.rs` |
| six unit tests on the arithmetic, two integration tests on the wiring | `event.rs`, `crates/hiroz-tests/tests/message_lost.rs` |

The tracker ignores a sample whose attachment is missing or undecodable. A plain zenoh peer sends no sequence number. hiroz must not treat such a peer as lossy just because it looks unfamiliar.

## Alignment with `rmw_zenoh_cpp`

The reference is `SubscriptionData::add_new_message`, upstream commit `e3159856e3816e726f2c5f1f9b4858ad6b7ee63e`. This section compares against its [gap logic](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp#L1149-L1168).

### Matched

| behaviour | `rmw_zenoh_cpp` | this PR |
|---|---|---|
| signal | gap in per-publisher sequence numbers | same |
| first sample from a publisher | no event | same |
| a gap of *n* reports | `n - 1` | same |
| saturates to `i32` | `std::clamp` | `min(i32::MAX)` |
| queue-depth drops counted | no — [debug log only](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp#L1131-L1137) | no — debug log only, in `DataHandler::handle` in `common.rs` |
| raised from | the receive path | same |

The depth-drop row is easy to get wrong. A sample dropped because the subscriber's queue is full **arrived**. It advanced the baseline, so it produces no gap. Neither implementation reports it as `MESSAGE_LOST`. This PR does not change that.

### Divergences, deliberate

**DV1 — an out-of-order arrival no longer reports phantom loss.** Upstream computes `std::abs(sn - last)` and rewrites the baseline unconditionally. This PR advances the baseline only forward, and reports nothing for an arrival at or below it.

| arrivals `5, 3, 6` | reported lost |
|---|---|
| `rmw_zenoh_cpp` | `abs(3-5)=2` → 1, then `abs(6-3)=3` → 2. Total **3 phantom** |
| this PR | **0** |

This is the recovery path, not a contrived input. Both implementations enable heartbeat-based miss detection on reliable subscribers: [`recovery->last_sample_miss_detection = RecoveryOptions::Heartbeat{}`](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp#L388) upstream, and [`RecoveryConfig::default().heartbeat()`](https://github.com/ZettaScaleLabs/hiroz/blob/604b0cd54bbb1165683a26a80ed8c15cbedc0b96/crates/hiroz/src/pubsub.rs#L115) here. Recovery exists precisely to deliver a missed sample *after* newer ones have arrived.

> [!NOTE]
> Upstream behaviour here comes from reading `rmw_subscription_data.cpp`, not from executing it. Both `on_sample` closures feed `add_new_message`, and both are installed via `declare_advanced_subscriber`. Live and recovered samples therefore share the same gap logic. The hiroz side is pinned by `message_loss_survives_a_transient_local_replay`.

**DV2 — no hash collisions between publishers.** Upstream keys its map on `hash_gid(...)`, a `size_t`. Two publishers whose GIDs collide would interleave their sequence numbers into one baseline, producing continuous phantom loss on both. This PR keys on the full 16-byte `GidArray`.

**DV3 — the callout happens with no subscriber lock held.** Upstream calls `update_event_status` from inside `add_new_message`. That method [holds `SubscriptionData::mutex_` for its whole body](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp#L1113-L1117) — the shape #259 is about. [`EventsManager::update_event_status`](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/event.cpp#L175-L198) does release `event_mutex_` before `trigger_event_callback`; the subscription mutex is the one still held. In this PR the per-GID map has its own lock, and the guard drops before the call to `update_shared_event_status`.

**DV4 — `std::clamp`'s lower bound is not copied.** Upstream clamps to `[i32::MIN, i32::MAX]`. The value is `abs(..) - 1` guarded by `abs(..) > 1`, so it cannot be negative. This PR saturates at `i32::MAX` only.

## Evidence

| direction | measurement | commit |
|---|---|---|
| implementation | all 26 GitHub checks completed successfully; `license/cla` green | `604b0cd54bbb1165683a26a80ed8c15cbedc0b96` |
| wiring removed | delete the `observe_loss(..)` call from the receive path: the six unit tests **still pass**, `a_sequence_gap_raises_message_lost` **fails** | measured locally by reverting that one line; not re-run since |

The second row is the point. The unit tests exercise `MessageLossTracker` directly, so they cannot see whether anything calls it. Without `message_lost.rs`, deleting the wiring would be a silent, green regression.

`crates/hiroz/src/event.rs` has 20 `#[test]` functions at the head commit, six of them new: ordinary gap, first sample, per-publisher isolation, reorder/republish, transient-local replay, and `i32` saturation.

The two integration tests induce loss deterministically. Each publishes onto the subscriber's own key expression through the node's session with a hand-built `Attachment`, so the gap is exact. Only one of the two is a detector:

| test | role |
|---|---|
| `a_sequence_gap_raises_message_lost` | **detector** — fails when the wiring is removed |
| `joining_late_reports_no_loss` | **guard**, not a detector: it asserts zero, and no wiring also produces zero |

## Breaking changes

None. Two API surfaces change shape, both additive:

| change | effect |
|---|---|
| `MessageLossTracker` in `hiroz::event` | new public type; nothing existing changes shape |
| `ZSub::events_mgr()` and `ZSub::entity()` moved to the generic `impl<T: ZMessage, Q, S: ZDeserializer>` | widening only — both were already available on `ZSub<T, Sample, S>`, and are now also reachable from callback-mode subscribers, which the rmw layer needs |

> [!IMPORTANT]
> A subscriber that previously saw `total_count == 0` forever now sees real counts. That is the purpose of this PR. It changes behaviour for anything asserting on that status.

## Coverage this does not have

None of these block the fix. They bound what green CI proves.

| tag | gap |
|---|---|
| **G1** | Loss is detected between publisher and subscriber only. A gap proves a sample did not arrive; it says nothing about why. |
| **G2** | Nothing covers a subscriber's own queue. See the depth-drop row above. |
| **G3** | A publisher that restarts its sequence numbering while keeping its GID goes quiet until it passes its previous high-water mark. |
| **G4** | No test drives real network loss. Loss is synthesised with hand-built attachments. |

**G3** is a deliberate trade. In ROS a restarted endpoint normally gets a fresh GID, so it lands in the first-sample path instead. The alternative is upstream's behaviour, which mis-reports every replay (**DV1**).

