### PR TITLE
ci: retry apt fetches instead of rerunning the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,22 @@ jobs:
       - name: Check formatting
         run: nix build .#checks.x86_64-linux.pre-commit-check -L
 
+  apt-retry:
+    name: CI apt wrapper
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # test.yml runs this wrapper on every interop leg, and test.yml is
+      # in this workflow's paths-ignore. Without a job here, a change to
+      # the wrapper reaches CI only by being used.
+      - name: Test the apt retry wrapper
+        run: ./scripts/ci/test-apt-retry.sh
+
   no-ros-test:
     name: ROS-independent Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # A healthy run never exercises this wrapper's failure paths. The
-      # mirror is usually up, so test.yml's apt calls succeed first try.
-      # The backoff, the mirror switch and both guards never execute. The
-      # run that added this job measured that: zero apt-retry lines on
-      # every interop leg.
-      #
-      # Draft pull requests also skip interop, so a wrapper change gets no
-      # coverage there at all.
+      # Interop runs this wrapper, but only its success path. This runs the
+      # retries, the mirror switch and the guards. See hiroz#308.
       - name: Test the apt retry wrapper
         run: ./scripts/ci/test-apt-retry.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # test.yml runs this wrapper on every interop leg, and test.yml is
-      # in this workflow's paths-ignore. Without a job here, a change to
-      # the wrapper reaches CI only by being used.
+      # A healthy run never exercises this wrapper's failure paths. The
+      # mirror is usually up, so test.yml's apt calls succeed first try.
+      # The backoff, the mirror switch and both guards never execute. The
+      # run that added this job measured that: zero apt-retry lines on
+      # every interop leg.
+      #
+      # Draft pull requests also skip interop, so a wrapper change gets no
+      # coverage there at all.
       - name: Test the apt retry wrapper
         run: ./scripts/ci/test-apt-retry.sh
 

--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -45,7 +45,17 @@ jobs:
 
     steps:
       - name: Install system dependencies
-        run: apt-get update && apt-get install -y git curl nodejs
+        run: |
+          # Ubuntu's archives fail to connect intermittently from GitHub-hosted
+          # runners — a long-reported, non-deterministic fault rather than an
+          # incident. Retry inside apt: a rerun discards the container pull that
+          # preceded the failure, and a job that is only sometimes green trains
+          # people to ignore red. The drop-in covers the ROS step below too.
+          #
+          # This workflow keeps the image's default mirror. test.yml repoints to
+          # Azure's for throughput and carries the same drop-in there.
+          printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
+          apt-get update && apt-get install -y git curl nodejs
 
       - name: Install ROS dependencies
         run: |

--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -45,42 +45,11 @@ jobs:
 
     steps:
       - name: Install system dependencies
-        run: |
-          # Ubuntu's archives fail to connect intermittently from GitHub-hosted
-          # runners — a long-reported, non-deterministic fault rather than an
-          # incident. Retry inside apt: a rerun discards the container pull that
-          # preceded the failure, and a job that is only sometimes green trains
-          # people to ignore red. The drop-in covers the ROS step below too.
-          #
-          # This workflow keeps the image's default mirror. test.yml repoints to
-          # Azure's for throughput and carries the same drop-in there.
-          printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
-
-          # Acquire::Retries re-attempts immediately, with no delay, so it
-          # covers a blip and not a window of tens of seconds. Wrap the command
-          # too. A file rather than a function, because each `run:` is its own
-          # shell and the repository is not checked out yet.
-          cat > /usr/local/bin/apt-retry <<'SH'
-          #!/bin/sh
-          n=0
-          until "$@"; do
-              n=$((n + 1))
-              if [ "$n" -ge 4 ]; then
-                  echo "apt-retry: '$*' failed after $n attempts" >&2
-                  exit 1
-              fi
-              echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
-              sleep $((n * 15))
-          done
-          SH
-          chmod +x /usr/local/bin/apt-retry
-
-          apt-retry apt-get update
-          apt-retry apt-get install -y git curl nodejs
+        run: apt-get update && apt-get install -y git curl nodejs
 
       - name: Install ROS dependencies
         run: |
-          apt-retry apt-get install -y \
+          apt-get install -y \
             ros-jazzy-rmw \
             ros-jazzy-rcutils \
             ros-jazzy-rcpputils \

--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -55,11 +55,32 @@ jobs:
           # This workflow keeps the image's default mirror. test.yml repoints to
           # Azure's for throughput and carries the same drop-in there.
           printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
-          apt-get update && apt-get install -y git curl nodejs
+
+          # Acquire::Retries re-attempts immediately, with no delay, so it
+          # covers a blip and not a window of tens of seconds. Wrap the command
+          # too. A file rather than a function, because each `run:` is its own
+          # shell and the repository is not checked out yet.
+          cat > /usr/local/bin/apt-retry <<'SH'
+          #!/bin/sh
+          n=0
+          until "$@"; do
+              n=$((n + 1))
+              if [ "$n" -ge 4 ]; then
+                  echo "apt-retry: '$*' failed after $n attempts" >&2
+                  exit 1
+              fi
+              echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
+              sleep $((n * 15))
+          done
+          SH
+          chmod +x /usr/local/bin/apt-retry
+
+          apt-retry apt-get update
+          apt-retry apt-get install -y git curl nodejs
 
       - name: Install ROS dependencies
         run: |
-          apt-get install -y \
+          apt-retry apt-get install -y \
             ros-jazzy-rmw \
             ros-jazzy-rcutils \
             ros-jazzy-rcpputils \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,11 +117,38 @@ jobs:
           # in the same place, the thing that makes it survivable.
           printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
 
+          # Acquire::Retries has no backoff -- it re-attempts immediately, so it
+          # covers a momentary blip and not a window lasting tens of seconds.
+          # Measured: with it in place, `Install ROS dependencies` still failed
+          # after 38s, because that step fetches hundreds of files and each one
+          # is another chance to hit the window.
+          #
+          # So wrap the whole command too, with a delay. Written to a file
+          # because every `run:` is a separate shell, and the repository is not
+          # checked out yet at this point in the job.
+          cat > /usr/local/bin/apt-retry <<'SH'
+          #!/bin/sh
+          # Run an apt command, retrying with backoff. The mirror is
+          # intermittently unreachable; see the step that selects it.
+          n=0
+          until "$@"; do
+              n=$((n + 1))
+              if [ "$n" -ge 4 ]; then
+                  echo "apt-retry: '$*' failed after $n attempts" >&2
+                  exit 1
+              fi
+              echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
+              sleep $((n * 15))
+          done
+          SH
+          chmod +x /usr/local/bin/apt-retry
+
       - name: Install system dependencies
         run: |
           # Install jq here so taiki-e/install-action's cargo-nextest step
           # below doesn't trigger a second, redundant apt-get update for it.
-          apt-get update && apt-get install -y nodejs jq
+          apt-retry apt-get update
+          apt-retry apt-get install -y nodejs jq
 
       - name: Install Nushell
         run: |
@@ -155,7 +182,7 @@ jobs:
           # #303 carries the diagnosis: the version pair, the valgrind trace and
           # the hypotheses it ruled out. Keep them there. A version number in a
           # comment goes stale, and a stale comment is worse than none.
-          apt-get install -y \
+          apt-retry apt-get install -y \
             ros-${{ matrix.distro }}-rclcpp \
             ros-${{ matrix.distro }}-example-interfaces \
             ros-${{ matrix.distro }}-rmw-zenoh-cpp \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,10 @@ jobs:
       # The ROS images ship git, so this needs nothing installed: checkout runs
       # `git init` rather than falling back to the API tarball.
       #
-      # It also makes `hashFiles` in the apt cache key below resolve. Before
-      # this move it ran against an empty workspace and returned nothing, so
-      # the key was constant and never tracked the workflow it names. Expect
-      # one cache miss as the key changes, then correct behaviour.
+      # The apt cache key below interpolates `hashFiles` over this file, and
+      # that only resolves once the workspace holds it. Keep checkout above
+      # that step, or the key silently becomes a constant and stops tracking
+      # the workflow it names.
       - uses: actions/checkout@v4
 
       - name: Compute weekly cache key
@@ -109,28 +109,16 @@ jobs:
               /etc/apt/sources.list.d/*.sources
           fi
 
-          # That mirror is fast and intermittently unreachable. `Unable to
-          # connect to azure.archive.ubuntu.com` is a long-standing,
-          # non-deterministic failure on GitHub-hosted runners, reported against
-          # actions/runner-images since 2019. It is not an incident that ends,
-          # so there is nothing to wait out: it has hit every distro here,
-          # passed unaided, and failed again through a rerun.
+          # That mirror is fast and intermittently unreachable, so every apt
+          # call below runs through `scripts/ci/apt-retry.sh`. That script
+          # carries the diagnosis and the measurement behind each layer. Keep
+          # them there rather than repeating them here.
           #
-          # Retry inside apt rather than rerunning the job. A rerun throws away
-          # the container pull and the cache restore that preceded the failure.
-          # It also teaches everyone to ignore red, because the job goes green
-          # often enough. That is how a real regression gets waved through.
-          #
-          # A drop-in rather than `-o` per command, so it also covers `Install
-          # ROS dependencies` below and anything added later. It lives in this
-          # step deliberately: whoever opts into the fast mirror should find,
-          # in the same place, the thing that makes it survivable.
+          # This drop-in is the one layer that belongs in this step, because it
+          # is apt configuration and not a wrapper. It retries a single file,
+          # with no delay, and covers a momentary blip. It applies to every apt
+          # call in the job, including any added later.
           printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
-
-          # Acquire::Retries has no backoff -- it re-attempts immediately, so it
-          # covers a momentary blip and not a window lasting tens of seconds.
-          # scripts/ci/apt-retry.sh adds the backoff and the mirror fallback,
-          # and carries the measurements that justify each layer.
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,14 +57,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      # First, so `scripts/ci/apt-retry.sh` exists before the apt steps below.
-      # The ROS images ship git, so this needs nothing installed: checkout runs
-      # `git init` rather than falling back to the API tarball.
-      #
-      # The apt cache key below interpolates `hashFiles` over this file, and
-      # that only resolves once the workspace holds it. Keep checkout above
-      # that step, or the key silently becomes a constant and stops tracking
-      # the workflow it names.
+      # Must stay first. Two things below break if it moves: the apt steps run
+      # `scripts/ci/apt-retry.sh`, and the cache key `hashFiles` over this file,
+      # which silently yields a constant against an empty workspace.
       - uses: actions/checkout@v4
 
       - name: Compute weekly cache key
@@ -77,14 +72,9 @@ jobs:
           path: /var/cache/apt/archives
           key: apt-${{ matrix.distro }}-v3-${{ hashFiles('.github/workflows/test.yml') }}
 
-      # The apt package-index fetch, not the package downloads, dominated this
-      # job when someone added this cache. Cache the index; a weekly key stops
-      # it going permanently stale, and a miss just re-fetches.
-      #
-      # That rationale cites ~900 B/s. Runs on 2026-08-19 do not reproduce it:
-      # a runner pulled 14.6 MB from archive.ubuntu.com at 5099 kB/s, and
-      # 37.3 MB from the Azure mirror at 443 kB/s. Treat the figure as
-      # unreproduced rather than current.
+      # Cache the package index, not just the .debs. A weekly key stops it
+      # going permanently stale; a miss just re-fetches. The ~900 B/s that
+      # justified this does not reproduce -- see hiroz#308.
       - name: Cache apt package lists
         uses: actions/cache@v4
         with:
@@ -98,17 +88,9 @@ jobs:
       # same-datacenter mirror. Handles both the legacy one-line sources.list
       # and the newer deb822 *.sources format.
       #
-      # The original rationale claimed 75-900 B/s from the generic endpoints.
-      # They do not behave that way now. On 2026-08-19 one of them served
-      # 14.6 MB at 5099 kB/s to a runner, during the fallback below. The Azure
-      # mirror managed 443 kB/s on another leg that day, and refused
-      # connections outright on a third.
-      #
-      # So the repointing may no longer earn the flakiness it brings. Settling
-      # that needs both hosts measured under the same conditions. Nothing here
-      # does that yet: a datapoint taken while the fast mirror was failing
-      # proves little. Until someone measures it, the mirror stays and the
-      # fallback covers it.
+      # The 75-900 B/s that justified this does not reproduce, and this mirror
+      # is the one that fails. Whether the repointing still earns its keep is
+      # open -- hiroz#308 carries the measurements and what would settle it.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then
@@ -126,15 +108,10 @@ jobs:
               /etc/apt/sources.list.d/*.sources
           fi
 
-          # That mirror is fast and intermittently unreachable, so every apt
-          # call below runs through `scripts/ci/apt-retry.sh`. That script
-          # carries the diagnosis and the measurement behind each layer. Keep
-          # them there rather than repeating them here.
-          #
-          # This drop-in is the one layer that belongs in this step, because it
-          # is apt configuration and not a wrapper. It retries a single file,
-          # with no delay, and covers a momentary blip. It applies to every apt
-          # call in the job, including any added later.
+          # This mirror is intermittently unreachable, so every apt call below
+          # goes through `scripts/ci/apt-retry.sh`. This drop-in is the layer
+          # that belongs here rather than in the wrapper: it is apt config, and
+          # it covers every apt call in the job, including any added later.
           printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
 
       - name: Install system dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,9 +87,10 @@ jobs:
       # same-datacenter mirror. Handles both the legacy one-line sources.list
       # and the newer deb822 *.sources format.
       #
-      # This mirror is the one that fails, and the throughput gap justifying
-      # it does not reproduce. Whether it still earns its keep is open --
-      # hiroz#308 has the measurements.
+      # This mirror is also the one that fails. Measured on all four runners
+      # (hiroz#308), it beats archive.ubuntu.com in every one of 12 pairs, by
+      # 2x to 13x. So it stays, and apt-retry.sh covers the windows when it is
+      # unreachable.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,14 @@ jobs:
           path: /var/cache/apt/archives
           key: apt-${{ matrix.distro }}-v3-${{ hashFiles('.github/workflows/test.yml') }}
 
-      # The apt package-index fetch (not the downloads) is the mirror bottleneck
-      # here (~900 B/s), costing minutes per job. Cache the index; keyed weekly
-      # so it can't go permanently stale — a miss just re-fetches.
+      # The apt package-index fetch, not the package downloads, dominated this
+      # job when someone added this cache. Cache the index; a weekly key stops
+      # it going permanently stale, and a miss just re-fetches.
+      #
+      # That rationale cites ~900 B/s. Runs on 2026-08-19 do not reproduce it:
+      # a runner pulled 14.6 MB from archive.ubuntu.com at 5099 kB/s, and
+      # 37.3 MB from the Azure mirror at 443 kB/s. Treat the figure as
+      # unreproduced rather than current.
       - name: Cache apt package lists
         uses: actions/cache@v4
         with:
@@ -88,10 +93,22 @@ jobs:
           restore-keys: |
             apt-lists-${{ matrix.distro }}-
 
-      # GitHub runners are on Azure, but the ROS base images point at the
-      # generic archive/security.ubuntu.com endpoints, which are slow from here
-      # (~75-900 B/s). Repoint to Azure's same-datacenter mirror. Handles both
-      # the legacy one-line sources.list and the newer deb822 *.sources format.
+      # GitHub runners are on Azure, and the ROS base images point at the
+      # generic archive/security.ubuntu.com endpoints. Repoint to Azure's
+      # same-datacenter mirror. Handles both the legacy one-line sources.list
+      # and the newer deb822 *.sources format.
+      #
+      # The original rationale claimed 75-900 B/s from the generic endpoints.
+      # They do not behave that way now. On 2026-08-19 one of them served
+      # 14.6 MB at 5099 kB/s to a runner, during the fallback below. The Azure
+      # mirror managed 443 kB/s on another leg that day, and refused
+      # connections outright on a third.
+      #
+      # So the repointing may no longer earn the flakiness it brings. Settling
+      # that needs both hosts measured under the same conditions. Nothing here
+      # does that yet: a datapoint taken while the fast mirror was failing
+      # proves little. Until someone measures it, the mirror stays and the
+      # fallback covers it.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,24 @@ jobs:
               /etc/apt/sources.list.d/*.sources
           fi
 
+          # That mirror is fast and intermittently unreachable. `Unable to
+          # connect to azure.archive.ubuntu.com` is a long-standing,
+          # non-deterministic failure on GitHub-hosted runners, reported against
+          # actions/runner-images since 2019. It is not an incident that ends,
+          # so there is nothing to wait out: it has hit every distro here,
+          # passed unaided, and failed again through a rerun.
+          #
+          # Retry inside apt rather than rerunning the job. A rerun throws away
+          # the container pull and cache restore that preceded the failure, and
+          # a job that only sometimes goes green teaches everyone to ignore red
+          # — which is how a real regression gets waved through.
+          #
+          # A drop-in rather than `-o` per command, so it also covers `Install
+          # ROS dependencies` below and anything added later. It lives in this
+          # step deliberately: whoever opts into the fast mirror should find,
+          # in the same place, the thing that makes it survivable.
+          printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
+
       - name: Install system dependencies
         run: |
           # Install jq here so taiki-e/install-action's cargo-nextest step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      # Must stay first. Two things below break if it moves: the apt steps run
-      # `scripts/ci/apt-retry.sh`, and the cache key `hashFiles` over this file,
-      # which silently yields a constant against an empty workspace.
+      # Must stay first: the apt steps run `scripts/ci/apt-retry.sh`, and the
+      # cache key hashes this file, yielding a constant on an empty workspace.
       - uses: actions/checkout@v4
 
       - name: Compute weekly cache key
@@ -73,8 +72,8 @@ jobs:
           key: apt-${{ matrix.distro }}-v3-${{ hashFiles('.github/workflows/test.yml') }}
 
       # Cache the package index, not just the .debs. A weekly key stops it
-      # going permanently stale; a miss just re-fetches. The fetch rate that
-      # justified this does not reproduce -- see hiroz#308.
+      # going stale; a miss re-fetches. The rate that justified it does not
+      # reproduce -- see hiroz#308.
       - name: Cache apt package lists
         uses: actions/cache@v4
         with:
@@ -88,10 +87,9 @@ jobs:
       # same-datacenter mirror. Handles both the legacy one-line sources.list
       # and the newer deb822 *.sources format.
       #
-      # The throughput gap that justified this does not reproduce, and this
-      # mirror is the one that fails. Whether the repointing still earns its
-      # keep is open -- hiroz#308 carries the measurements and what would
-      # settle it.
+      # This mirror is the one that fails, and the throughput gap justifying
+      # it does not reproduce. Whether it still earns its keep is open --
+      # hiroz#308 has the measurements.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then
@@ -109,10 +107,9 @@ jobs:
               /etc/apt/sources.list.d/*.sources
           fi
 
-          # This mirror is intermittently unreachable, so every apt call below
-          # goes through `scripts/ci/apt-retry.sh`. This drop-in is the layer
-          # that belongs here rather than in the wrapper: it is apt config, and
-          # it covers every apt call in the job, including any added later.
+          # Every apt call below goes through `scripts/ci/apt-retry.sh`. This
+          # drop-in belongs here rather than in the wrapper: it is apt config,
+          # so it covers every apt call in the job, including any added later.
           printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/99-retries
 
       - name: Install system dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,20 +126,58 @@ jobs:
           # So wrap the whole command too, with a delay. Written to a file
           # because every `run:` is a separate shell, and the repository is not
           # checked out yet at this point in the job.
+          # Measured: backoff alone is not enough either. With 15s/30s/45s in
+          # place, `Install system dependencies` ran for 127 seconds -- four
+          # attempts and every sleep -- and still failed. The mirror can be
+          # unreachable for longer than any backoff worth waiting through.
+          #
+          # So fall back. The generic endpoints are slow, which is the whole
+          # reason for repointing above, but slow beats failed: a job that takes
+          # a few more minutes still tells you whether your code works, and one
+          # that dies on a package fetch tells you nothing.
+          cat > /usr/local/bin/apt-fallback-mirror <<'SH'
+          #!/bin/sh
+          # Undo the Azure repointing. Same file shapes as the step above.
+          echo "apt-retry: switching to the generic Ubuntu mirror" >&2
+          if [ -f /etc/apt/sources.list ]; then
+              sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+                  /etc/apt/sources.list
+          fi
+          if ls /etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
+              sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+                  /etc/apt/sources.list.d/*.sources
+          fi
+          SH
+          chmod +x /usr/local/bin/apt-fallback-mirror
+
           cat > /usr/local/bin/apt-retry <<'SH'
           #!/bin/sh
-          # Run an apt command, retrying with backoff. The mirror is
-          # intermittently unreachable; see the step that selects it.
-          n=0
-          until "$@"; do
-              n=$((n + 1))
-              if [ "$n" -ge 4 ]; then
-                  echo "apt-retry: '$*' failed after $n attempts" >&2
-                  exit 1
-              fi
-              echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
-              sleep $((n * 15))
-          done
+          # Run an apt command with backoff, then once more against the generic
+          # mirror if the fast one never came back.
+          attempt() {
+              n=0
+              until "$@"; do
+                  n=$((n + 1))
+                  [ "$n" -ge 4 ] && return 1
+                  echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
+                  sleep $((n * 15))
+              done
+              return 0
+          }
+
+          attempt "$@" && exit 0
+
+          # One fallback per job: the flag stops a later apt call repeating the
+          # switch and re-reporting it as news.
+          if [ ! -f /var/tmp/.apt-fell-back ]; then
+              apt-fallback-mirror
+              : > /var/tmp/.apt-fell-back
+              apt-get update >/dev/null 2>&1 || true
+          fi
+
+          attempt "$@" && exit 0
+          echo "apt-retry: '$*' failed on both mirrors" >&2
+          exit 1
           SH
           chmod +x /usr/local/bin/apt-retry
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,16 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
+      # First, so `scripts/ci/apt-retry.sh` exists before the apt steps below.
+      # The ROS images ship git, so this needs nothing installed: checkout runs
+      # `git init` rather than falling back to the API tarball.
+      #
+      # It also makes `hashFiles` in the apt cache key below resolve. Before
+      # this move it ran against an empty workspace and returned nothing, so
+      # the key was constant and never tracked the workflow it names. Expect
+      # one cache miss as the key changes, then correct behaviour.
+      - uses: actions/checkout@v4
+
       - name: Compute weekly cache key
         id: cache-week
         run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
@@ -119,74 +129,15 @@ jobs:
 
           # Acquire::Retries has no backoff -- it re-attempts immediately, so it
           # covers a momentary blip and not a window lasting tens of seconds.
-          # Measured: with it in place, `Install ROS dependencies` still failed
-          # after 38s. That step fetches hundreds of files. Each one is another
-          # chance to hit the window.
-          #
-          # So wrap the whole command too, with a delay. Written to a file
-          # because every `run:` is a separate shell, and the repository is not
-          # checked out yet at this point in the job.
-          # Measured: backoff alone is not enough either. With 15s/30s/45s in
-          # place, `Install system dependencies` ran for 127 seconds -- four
-          # attempts and every sleep -- and still failed. The mirror can be
-          # unreachable for longer than any backoff worth waiting through.
-          #
-          # So fall back. The generic endpoints are slow, which is the whole
-          # reason for repointing above. Slow still beats failed. A job that
-          # takes a few more minutes tells you whether your code works. A job
-          # that dies on a package fetch tells you nothing.
-          cat > /usr/local/bin/apt-fallback-mirror <<'SH'
-          #!/bin/sh
-          # Undo the Azure repointing. Same file shapes as the step above.
-          echo "apt-retry: switching to the generic Ubuntu mirror" >&2
-          if [ -f /etc/apt/sources.list ]; then
-              sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-                  /etc/apt/sources.list
-          fi
-          if ls /etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
-              sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-                  /etc/apt/sources.list.d/*.sources
-          fi
-          SH
-          chmod +x /usr/local/bin/apt-fallback-mirror
-
-          cat > /usr/local/bin/apt-retry <<'SH'
-          #!/bin/sh
-          # Run an apt command with backoff, then once more against the generic
-          # mirror if the fast one never came back.
-          attempt() {
-              n=0
-              until "$@"; do
-                  n=$((n + 1))
-                  [ "$n" -ge 4 ] && return 1
-                  echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
-                  sleep $((n * 15))
-              done
-              return 0
-          }
-
-          attempt "$@" && exit 0
-
-          # One fallback per job: the flag stops a later apt call repeating the
-          # switch and re-reporting it as news.
-          if [ ! -f /var/tmp/.apt-fell-back ]; then
-              apt-fallback-mirror
-              : > /var/tmp/.apt-fell-back
-              apt-get update >/dev/null 2>&1 || true
-          fi
-
-          attempt "$@" && exit 0
-          echo "apt-retry: '$*' failed on both mirrors" >&2
-          exit 1
-          SH
-          chmod +x /usr/local/bin/apt-retry
+          # scripts/ci/apt-retry.sh adds the backoff and the mirror fallback,
+          # and carries the measurements that justify each layer.
 
       - name: Install system dependencies
         run: |
           # Install jq here so taiki-e/install-action's cargo-nextest step
           # below doesn't trigger a second, redundant apt-get update for it.
-          apt-retry apt-get update
-          apt-retry apt-get install -y nodejs jq
+          scripts/ci/apt-retry.sh apt-get update
+          scripts/ci/apt-retry.sh apt-get install -y nodejs jq
 
       - name: Install Nushell
         run: |
@@ -220,7 +171,7 @@ jobs:
           # #303 carries the diagnosis: the version pair, the valgrind trace and
           # the hypotheses it ruled out. Keep them there. A version number in a
           # comment goes stale, and a stale comment is worse than none.
-          apt-retry apt-get install -y \
+          scripts/ci/apt-retry.sh apt-get install -y \
             ros-${{ matrix.distro }}-rclcpp \
             ros-${{ matrix.distro }}-example-interfaces \
             ros-${{ matrix.distro }}-rmw-zenoh-cpp \
@@ -282,8 +233,6 @@ jobs:
             sed -i '/transport_optimization:/,/},$/d' "$CONFIG_FILE"
             echo "Fixed rmw_zenoh_cpp config by removing invalid transport_optimization section"
           fi
-
-      - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,9 @@ jobs:
           # passed unaided, and failed again through a rerun.
           #
           # Retry inside apt rather than rerunning the job. A rerun throws away
-          # the container pull and cache restore that preceded the failure, and
-          # a job that only sometimes goes green teaches everyone to ignore red
-          # — which is how a real regression gets waved through.
+          # the container pull and the cache restore that preceded the failure.
+          # It also teaches everyone to ignore red, because the job goes green
+          # often enough. That is how a real regression gets waved through.
           #
           # A drop-in rather than `-o` per command, so it also covers `Install
           # ROS dependencies` below and anything added later. It lives in this
@@ -120,8 +120,8 @@ jobs:
           # Acquire::Retries has no backoff -- it re-attempts immediately, so it
           # covers a momentary blip and not a window lasting tens of seconds.
           # Measured: with it in place, `Install ROS dependencies` still failed
-          # after 38s, because that step fetches hundreds of files and each one
-          # is another chance to hit the window.
+          # after 38s. That step fetches hundreds of files. Each one is another
+          # chance to hit the window.
           #
           # So wrap the whole command too, with a delay. Written to a file
           # because every `run:` is a separate shell, and the repository is not
@@ -132,8 +132,8 @@ jobs:
           # unreachable for longer than any backoff worth waiting through.
           #
           # So fall back. The generic endpoints are slow, which is the whole
-          # reason for repointing above, but slow beats failed: a job that takes
-          # a few more minutes still tells you whether your code works, and one
+          # reason for repointing above. Slow still beats failed. A job that
+          # takes a few more minutes tells you whether your code works. A job
           # that dies on a package fetch tells you nothing.
           cat > /usr/local/bin/apt-fallback-mirror <<'SH'
           #!/bin/sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           key: apt-${{ matrix.distro }}-v3-${{ hashFiles('.github/workflows/test.yml') }}
 
       # Cache the package index, not just the .debs. A weekly key stops it
-      # going permanently stale; a miss just re-fetches. The ~900 B/s that
+      # going permanently stale; a miss just re-fetches. The fetch rate that
       # justified this does not reproduce -- see hiroz#308.
       - name: Cache apt package lists
         uses: actions/cache@v4
@@ -88,9 +88,10 @@ jobs:
       # same-datacenter mirror. Handles both the legacy one-line sources.list
       # and the newer deb822 *.sources format.
       #
-      # The 75-900 B/s that justified this does not reproduce, and this mirror
-      # is the one that fails. Whether the repointing still earns its keep is
-      # open -- hiroz#308 carries the measurements and what would settle it.
+      # The throughput gap that justified this does not reproduce, and this
+      # mirror is the one that fails. Whether the repointing still earns its
+      # keep is open -- hiroz#308 carries the measurements and what would
+      # settle it.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,10 +87,9 @@ jobs:
       # same-datacenter mirror. Handles both the legacy one-line sources.list
       # and the newer deb822 *.sources format.
       #
-      # This mirror is also the one that fails. Measured on all four runners
-      # (hiroz#308), it beats archive.ubuntu.com in every one of 12 pairs, by
-      # 2x to 13x. So it stays, and apt-retry.sh covers the windows when it is
-      # unreachable.
+      # This mirror is also the one that fails. It still wins: it beat
+      # archive.ubuntu.com in all 12 pairs on four runners, by 2x to 13x.
+      # apt-retry.sh covers the windows when it is down. See hiroz#308.
       - name: Point apt at the Azure Ubuntu mirror
         run: |
           if [ -f /etc/apt/sources.list ]; then

--- a/scripts/ci/apt-retry.sh
+++ b/scripts/ci/apt-retry.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Run an apt command so that an unreachable mirror does not fail the job.
+#
+#   apt-retry.sh apt-get update
+#   apt-retry.sh apt-get install -y foo bar
+#
+# `Unable to connect to azure.archive.ubuntu.com` is a long-standing,
+# non-deterministic failure on GitHub-hosted runners. People have reported it
+# against actions/runner-images since 2019. It is not an incident that ends, so
+# there is nothing to wait out. In one day it hit every distro in the interop
+# matrix, let go for a whole run, then came back through a rerun.
+#
+# Three layers. Each earned its place: a measurement showed the one before it
+# was not enough.
+#
+#   Acquire::Retries      set by the workflow. Retries a single file, with no
+#                         delay. Covers a momentary blip. With it alone,
+#                         `Install ROS dependencies` still failed after 38s.
+#   backoff, here         retries the whole command: 15s, 30s, 45s. With this
+#                         alone, `Install system dependencies` ran 127 seconds
+#                         -- every attempt and every sleep -- and still failed.
+#   generic mirror, here  the endpoints the workflow repoints away from. Slow,
+#                         and reachable when the fast one is not.
+#
+# Both later layers have since rescued a real job: the backoff on lyrical, the
+# mirror switch on jazzy after roughly four minutes of an unreachable host.
+#
+# Retrying here beats rerunning the job. A rerun throws away the container pull
+# and the cache restore that preceded the failure. It also teaches everyone to
+# ignore red, because the job goes green often enough.
+set -u
+
+# One switch per job. Without the flag a later apt call repeats it and reports
+# it again as though it were news.
+FLAG=/var/tmp/.apt-fell-back
+
+# Undo what the workflow's mirror step did. The two file shapes match it: the
+# legacy one-line sources.list and the newer deb822 *.sources.
+fallback_mirror() {
+    echo "apt-retry: switching to the generic Ubuntu mirror" >&2
+    if [ -f /etc/apt/sources.list ]; then
+        sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list
+    fi
+    # Guard with `ls`: with nullglob off a non-matching glob expands to the
+    # literal pattern, so do not rely on the match itself.
+    if ls /etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
+        sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/*.sources
+    fi
+}
+
+attempt() {
+    n=0
+    until "$@"; do
+        n=$((n + 1))
+        [ "$n" -ge 4 ] && return 1
+        echo "apt-retry: attempt $n failed; retrying in $((n * 15))s" >&2
+        sleep $((n * 15))
+    done
+    return 0
+}
+
+attempt "$@" && exit 0
+
+if [ ! -f "$FLAG" ]; then
+    fallback_mirror
+    : > "$FLAG"
+    # Best effort. The caller's own command fails on its own terms if the index
+    # is unusable, and that failure is the more informative one.
+    apt-get update > /dev/null 2>&1 || true
+fi
+
+attempt "$@" && exit 0
+echo "apt-retry: '$*' failed on both mirrors" >&2
+exit 1

--- a/scripts/ci/apt-retry.sh
+++ b/scripts/ci/apt-retry.sh
@@ -14,19 +14,21 @@ set -u
 [ "$#" -gt 0 ] || { echo "apt-retry: usage: apt-retry.sh <command> [args...]" >&2; exit 2; }
 
 # One switch per job; without the flag a later apt call repeats it.
-FLAG=/var/tmp/.apt-fell-back
+# Both paths are overridable so test-apt-retry.sh drives a fixture tree.
+FLAG="${APT_RETRY_FLAG:-/var/tmp/.apt-fell-back}"
+ROOT="${APT_RETRY_ROOT:-}"
 
 # Undo the workflow mirror step. Same two file shapes it handles.
 fallback_mirror() {
     echo "apt-retry: switching to the generic Ubuntu mirror" >&2
-    if [ -f /etc/apt/sources.list ]; then
+    if [ -f "$ROOT/etc/apt/sources.list" ]; then
         sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list
+            "$ROOT/etc/apt/sources.list"
     fi
     # Guard with `ls`: a non-matching glob expands to the literal pattern.
-    if ls /etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
+    if ls "$ROOT"/etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
         sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list.d/*.sources
+            "$ROOT"/etc/apt/sources.list.d/*.sources
     fi
 }
 

--- a/scripts/ci/apt-retry.sh
+++ b/scripts/ci/apt-retry.sh
@@ -14,7 +14,7 @@ set -u
 [ "$#" -gt 0 ] || { echo "apt-retry: usage: apt-retry.sh <command> [args...]" >&2; exit 2; }
 
 # One switch per job; without the flag a later apt call repeats it.
-# Both paths are overridable so test-apt-retry.sh drives a fixture tree.
+# test-apt-retry.sh overrides both paths to drive a fixture tree.
 FLAG="${APT_RETRY_FLAG:-/var/tmp/.apt-fell-back}"
 ROOT="${APT_RETRY_ROOT:-}"
 

--- a/scripts/ci/apt-retry.sh
+++ b/scripts/ci/apt-retry.sh
@@ -4,30 +4,17 @@
 #   apt-retry.sh apt-get update
 #   apt-retry.sh apt-get install -y foo bar
 #
-# `Unable to connect to azure.archive.ubuntu.com` is a long-standing,
-# non-deterministic failure on GitHub-hosted runners. People have reported it
-# against actions/runner-images since 2019. It is not an incident that ends, so
-# there is nothing to wait out. In one day it hit every distro in the interop
-# matrix, let go for a whole run, then came back through a rerun.
+# `Unable to connect to azure.archive.ubuntu.com` fails GitHub-hosted runners
+# at random. It is a long-standing fault, not an incident that ends, so there
+# is nothing to wait out.
 #
-# Three layers. Each earned its place: a measurement showed the one before it
-# was not enough.
+# Three layers, each added because a measurement showed the previous one was
+# not enough. hiroz#308 carries those measurements and the runs behind them.
 #
-#   Acquire::Retries      set by the workflow. Retries a single file, with no
-#                         delay. Covers a momentary blip. With it alone,
-#                         `Install ROS dependencies` still failed after 38s.
-#   backoff, here         retries the whole command: 15s, 30s, 45s. With this
-#                         alone, `Install system dependencies` ran 127 seconds
-#                         -- every attempt and every sleep -- and still failed.
-#   generic mirror, here  the endpoints the workflow repoints away from. Slow,
-#                         and reachable when the fast one is not.
-#
-# Both later layers have since rescued a real job: the backoff on lyrical, the
-# mirror switch on jazzy after roughly four minutes of an unreachable host.
-#
-# Retrying here beats rerunning the job. A rerun throws away the container pull
-# and the cache restore that preceded the failure. It also teaches everyone to
-# ignore red, because the job goes green often enough.
+#   Acquire::Retries   set by the workflow. One file, no delay, covers a blip.
+#   backoff, here      the whole command: 15s, 30s, 45s.
+#   generic mirror     what the workflow repoints away from. Slower, and
+#                      reachable when the fast one is not.
 set -u
 
 # One switch per job. Without the flag a later apt call repeats it and reports

--- a/scripts/ci/apt-retry.sh
+++ b/scripts/ci/apt-retry.sh
@@ -1,36 +1,29 @@
 #!/bin/sh
-# Run an apt command so that an unreachable mirror does not fail the job.
+# Run an apt command so an unreachable mirror does not fail the job.
 #
 #   apt-retry.sh apt-get update
 #   apt-retry.sh apt-get install -y foo bar
 #
-# `Unable to connect to azure.archive.ubuntu.com` fails GitHub-hosted runners
-# at random. It is a long-standing fault, not an incident that ends, so there
-# is nothing to wait out.
-#
-# Three layers, each added because a measurement showed the previous one was
-# not enough. hiroz#308 carries those measurements and the runs behind them.
-#
-#   Acquire::Retries   set by the workflow. One file, no delay, covers a blip.
-#   backoff, here      the whole command: 15s, 30s, 45s.
-#   generic mirror     what the workflow repoints away from. Slower, and
-#                      reachable when the fast one is not.
+# Retries the command with backoff, then once against the generic mirror. The
+# workflow sets Acquire::Retries, which covers a single file with no delay.
+# hiroz#308 has the measurement behind each layer.
 set -u
 
-# One switch per job. Without the flag a later apt call repeats it and reports
-# it again as though it were news.
+# Refuse to do nothing quietly: with no command, `until "$@"` succeeds and this
+# would exit 0 having run no apt at all.
+[ "$#" -gt 0 ] || { echo "apt-retry: usage: apt-retry.sh <command> [args...]" >&2; exit 2; }
+
+# One switch per job; without the flag a later apt call repeats it.
 FLAG=/var/tmp/.apt-fell-back
 
-# Undo what the workflow's mirror step did. The two file shapes match it: the
-# legacy one-line sources.list and the newer deb822 *.sources.
+# Undo the workflow mirror step. Same two file shapes it handles.
 fallback_mirror() {
     echo "apt-retry: switching to the generic Ubuntu mirror" >&2
     if [ -f /etc/apt/sources.list ]; then
         sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
             /etc/apt/sources.list
     fi
-    # Guard with `ls`: with nullglob off a non-matching glob expands to the
-    # literal pattern, so do not rely on the match itself.
+    # Guard with `ls`: a non-matching glob expands to the literal pattern.
     if ls /etc/apt/sources.list.d/*.sources > /dev/null 2>&1; then
         sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
             /etc/apt/sources.list.d/*.sources
@@ -53,8 +46,7 @@ attempt "$@" && exit 0
 if [ ! -f "$FLAG" ]; then
     fallback_mirror
     : > "$FLAG"
-    # Best effort. The caller's own command fails on its own terms if the index
-    # is unusable, and that failure is the more informative one.
+    # Best effort; the caller fails on its own terms if the index is unusable.
     apt-get update > /dev/null 2>&1 || true
 fi
 

--- a/scripts/ci/test-apt-retry.sh
+++ b/scripts/ci/test-apt-retry.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Test scripts/ci/apt-retry.sh against stub commands.
+#
+#   scripts/ci/test-apt-retry.sh
+#
+# No apt and no network. Stubs on PATH stand in for the apt command and for
+# `sleep`, so the backoff costs nothing here. A fixture tree stands in for
+# /etc/apt, so the mirror rewrite is checked rather than assumed.
+set -u
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SUT="$HERE/apt-retry.sh"
+WORK="${APT_RETRY_TEST_DIR:-$HERE/../../_tmp/apt-retry-test}"
+
+rm -rf "$WORK"
+mkdir -p "$WORK/bin"
+BIN="$WORK/bin"
+PATH="$BIN:$PATH"
+export PATH
+
+# `sleep` is stubbed, so the 15s/30s/45s backoff does not slow the test. That
+# means the test proves the retry count, not the delays.
+printf '#!/bin/sh\nexit 0\n' > "$BIN/sleep"
+# fallback_mirror runs `apt-get update`. Keep it out of the call count.
+printf '#!/bin/sh\nexit 0\n' > "$BIN/apt-get"
+printf '#!/bin/sh\necho x >> "$CALLS"\nexit 0\n' > "$BIN/stub-ok"
+printf '#!/bin/sh\necho x >> "$CALLS"\nexit 1\n' > "$BIN/stub-fail"
+# Succeeds only once the switch has happened, so it separates the two attempts.
+printf '#!/bin/sh\necho x >> "$CALLS"\n[ -f "$APT_RETRY_FLAG" ]\n' > "$BIN/stub-until-switch"
+chmod +x "$BIN"/*
+
+PASS=0
+FAIL=0
+
+check() { # label, expected, actual
+    if [ "$2" = "$3" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $1: expected '$2', got '$3'" >&2
+    fi
+}
+
+# Each case gets its own flag path and call log, so no case sees another's state.
+setup() { # case name
+    CASE="$WORK/$1"
+    mkdir -p "$CASE"
+    CALLS="$CASE/calls"
+    : > "$CALLS"
+    APT_RETRY_FLAG="$CASE/flag"
+    APT_RETRY_ROOT="$CASE/root"
+    export CALLS APT_RETRY_FLAG APT_RETRY_ROOT
+}
+
+calls() { wc -l < "$CALLS" | tr -d ' '; }
+# grep -c prints 0 and exits 1 when it matches nothing. An `|| echo 0`
+# here would append a second zero, so let the count stand on its own.
+switches() { grep -c 'switching to the generic' "$CASE/err" 2>/dev/null; }
+
+run() { # runs the SUT, capturing stderr and rc
+    "$SUT" "$@" > "$CASE/out" 2> "$CASE/err"
+    echo $?
+}
+
+echo "== no arguments =="
+setup no-args
+RC=$(run)
+check "no args rc" 2 "$RC"
+check "no args names usage" 1 "$(grep -c 'usage' "$CASE/err")"
+check "no args runs nothing" 0 "$(calls)"
+
+echo "== command succeeds =="
+setup ok
+RC=$(run stub-ok)
+check "ok rc" 0 "$RC"
+check "ok runs once" 1 "$(calls)"
+check "ok never switches" 0 "$(switches)"
+
+echo "== command always fails =="
+setup fail
+RC=$(run stub-fail)
+check "fail rc" 1 "$RC"
+check "fail runs four times per mirror" 8 "$(calls)"
+check "fail switches once" 1 "$(switches)"
+check "fail names both mirrors" 1 "$(grep -c 'failed on both mirrors' "$CASE/err")"
+
+echo "== fails on the fast mirror, succeeds on the generic one =="
+setup recover
+RC=$(run stub-until-switch)
+check "recover rc" 0 "$RC"
+check "recover runs four times, then once" 5 "$(calls)"
+check "recover switches once" 1 "$(switches)"
+
+echo "== a job that already switched does not switch again =="
+setup already
+mkdir -p "$(dirname "$APT_RETRY_FLAG")"
+: > "$APT_RETRY_FLAG"
+RC=$(run stub-fail)
+check "already rc" 1 "$RC"
+check "already switches zero times" 0 "$(switches)"
+check "already still retries both rounds" 8 "$(calls)"
+
+echo "== the switch rewrites both sources file shapes =="
+setup rewrite
+mkdir -p "$APT_RETRY_ROOT/etc/apt/sources.list.d"
+AZ=http://azure.archive.ubuntu.com/ubuntu
+echo "deb $AZ noble main" > "$APT_RETRY_ROOT/etc/apt/sources.list"
+printf 'Types: deb\nURIs: %s\n' "$AZ" > "$APT_RETRY_ROOT/etc/apt/sources.list.d/ubuntu.sources"
+run stub-fail > /dev/null
+check "sources.list loses the azure host" 0 \
+    "$(grep -c 'azure' "$APT_RETRY_ROOT/etc/apt/sources.list")"
+check "sources.list gains the generic host" 1 \
+    "$(grep -c 'http://archive.ubuntu.com/ubuntu' "$APT_RETRY_ROOT/etc/apt/sources.list")"
+check "deb822 loses the azure host" 0 \
+    "$(grep -c 'azure' "$APT_RETRY_ROOT/etc/apt/sources.list.d/ubuntu.sources")"
+check "deb822 gains the generic host" 1 \
+    "$(grep -c 'http://archive.ubuntu.com/ubuntu' "$APT_RETRY_ROOT/etc/apt/sources.list.d/ubuntu.sources")"
+
+echo
+echo "apt-retry: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/ci/test-apt-retry.sh
+++ b/scripts/ci/test-apt-retry.sh
@@ -3,9 +3,9 @@
 #
 #   scripts/ci/test-apt-retry.sh
 #
-# No apt and no network. Stubs on PATH stand in for the apt command and for
-# `sleep`, so the backoff costs nothing here. A fixture tree stands in for
-# /etc/apt, so the mirror rewrite is checked rather than assumed.
+# It needs no apt and no network. Stubs on PATH replace the apt command and
+# sleep, so the backoff costs no time. A fixture tree replaces /etc/apt, so
+# the test checks the mirror rewrite.
 set -u
 
 HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -18,14 +18,14 @@ BIN="$WORK/bin"
 PATH="$BIN:$PATH"
 export PATH
 
-# `sleep` is stubbed, so the 15s/30s/45s backoff does not slow the test. That
-# means the test proves the retry count, not the delays.
+# The sleep stub removes the 15s/30s/45s backoff. So the test proves the
+# retry count, not the delays.
 printf '#!/bin/sh\nexit 0\n' > "$BIN/sleep"
 # fallback_mirror runs `apt-get update`. Keep it out of the call count.
 printf '#!/bin/sh\nexit 0\n' > "$BIN/apt-get"
 printf '#!/bin/sh\necho x >> "$CALLS"\nexit 0\n' > "$BIN/stub-ok"
 printf '#!/bin/sh\necho x >> "$CALLS"\nexit 1\n' > "$BIN/stub-fail"
-# Succeeds only once the switch has happened, so it separates the two attempts.
+# It succeeds only after the switch, so it separates the two attempts.
 printf '#!/bin/sh\necho x >> "$CALLS"\n[ -f "$APT_RETRY_FLAG" ]\n' > "$BIN/stub-until-switch"
 chmod +x "$BIN"/*
 
@@ -53,8 +53,8 @@ setup() { # case name
 }
 
 calls() { wc -l < "$CALLS" | tr -d ' '; }
-# grep -c prints 0 and exits 1 when it matches nothing. An `|| echo 0`
-# here would append a second zero, so let the count stand on its own.
+# grep -c prints 0 and exits 1 on no match. An `|| echo 0` here would
+# add a second zero.
 switches() { grep -c 'switching to the generic' "$CASE/err" 2>/dev/null; }
 
 run() { # runs the SUT, capturing stderr and rc


### PR DESCRIPTION
## Summary

Interop jobs fail at random on `Unable to connect to azure.archive.ubuntu.com`, before any hiroz code compiles. This retries the fetch, then falls back to the generic mirror, so a job survives a window instead of needing a rerun.

## What fails without this

`apt-get` exits 100 in `Install system dependencies` or `Install ROS dependencies`:

```
Err:7 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
  Unable to connect to azure.archive.ubuntu.com:http:
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

**Not an incident.** GitHub Status showed no outage at the time. People have reported this fault against `actions/runner-images` since 2019.

**How often it bites.** The last 60 Interop runs, across all branches:

| Day | Runs | apt failures |
|---|---|---|
| 2026-08-14 | 27 | 0 |
| 2026-08-18 | 15 | 3 |
| 2026-08-19 | 18 | 3 |

Six of the eight failures in that sample were apt. The other two were test failures. On `main` the last 30 runs reach back to late July, and none of them failed on apt.

So this is a burst, not a steady state. It starts on 2026-08-18, and it may already have passed. While it was open, about one interop run in five died before hiroz compiled. Read this PR as insurance against the next one, not as a fix for something failing today.

## Three layers, each added because the previous measured short

| Layer | Where | Why the next one was still needed |
|---|---|---|
| `Acquire::Retries "3"` | workflow | One file, no delay. `Install ROS dependencies` still failed after 38s — it fetches hundreds of files, so each is another chance to hit the window. |
| Backoff 15s/30s/45s | `apt-retry.sh` | `Install system dependencies` ran **127s** — four attempts and every sleep — and still failed. |
| Generic-mirror fallback | `apt-retry.sh` | — |

Both later layers have since rescued a real job:

```
lyrical:  attempt 1 failed; retrying in 15s                → succeeded
jazzy:    attempt 1 failed; retrying in 15s
          attempt 2 failed; retrying in 30s
          attempt 3 failed; retrying in 45s
          switching to the generic Ubuntu mirror           → succeeded
```

`Acquire::Retries` stays unproven: apt prints nothing when it fires, so no log can show it working. The wrapper logs every attempt, which is why the two results above are readable.

## Why retry rather than rerun

A rerun discards the container pull and cache restore that preceded the failure, spending ten minutes on what apt retries in seconds. It also does not converge — one rerun here failed identically. And a job that is only sometimes green trains reviewers to ignore red.

## Why not change the mirror

`test.yml` repoints to `azure.archive.ubuntu.com` deliberately, citing 75-900 B/s from the generic endpoints. That figure does not reproduce. `archive.ubuntu.com` is Cloudflare-backed now, so the reasoning behind the repointing looked stale. From a workstation the generic host measured 3-4x **faster** than the Azure mirror.

A workstation is not a runner. A runner sits inside Azure, and geo-routing sends each client somewhere different. So I measured both hosts from a runner, over three alternating rounds, on all four distro legs.

**The Azure mirror wins every one of the 12 pairs**, in kB/s:

| Leg | Azure mirror | archive.ubuntu.com |
|---|---|---|
| humble | 109046 / 54831 / 78222 | 23067 / 30759 / 28664 |
| jazzy | 39071 / 101320 / 64308 | 26051 / 44415 / 58886 |
| kilted | 70131 / 100719 / 113415 | 5885 / 10273 / 10453 |
| lyrical | 51505 / 95984 / 47582 | 3776 / 10502 / 10690 |

The two sets do not overlap on any leg. The margin runs from 1.1x to 13x.

So the repointing keeps its justification, and the workstation result was answering a different question. The fallback is correctly a fallback: slower, but reachable when the fast mirror is not. The measurement step was temporary, and this PR removes it.

## What apt's own advice would do

The error suggests `apt-get update` or `--fix-missing`. The first is what failed. The second skips what it could not fetch and exits 0. `nodejs` and `jq` would be absent, and the job would fail later at `command not found`. That replaces a loud failure with a quiet one.

## Testing

No one can make CI fail on demand, so `scripts/ci/test-apt-retry.sh` drives the wrapper against stub commands. It needs no apt and no network. Stubs shadow the apt command and `sleep`, so the backoff costs no wall-clock time. A fixture tree stands in for `/etc/apt`, so the test checks the mirror rewrite rather than assuming it. A CI job runs it.

Twenty assertions cover six cases:

| Case | Asserts |
|---|---|
| no arguments | exits 2 with a usage line, and runs no apt |
| succeeds first try | one call, no mirror switch |
| fails on both mirrors | four calls per mirror, one switch, names both |
| recovers after the switch | four calls, then one, exit 0 |
| job already switched | no second switch, both rounds still run |
| the switch itself | rewrites `sources.list` and deb822 `*.sources` |

**The assertions bite.** Four mutations to the wrapper each turn it red:

| Mutation | Caught by |
|---|---|
| retry ceiling 4 → 2 | three call-count assertions |
| flag guard removed | `already switches zero times` |
| replacement host wrong | both rewrite assertions |
| usage guard removed | `no args rc: expected 2, got 0` |

The last one reproduces the silent success this branch fixed: without the guard the wrapper exits 0 having run no apt. That case is now pinned.

## Incidental fix

The apt cache key hashes `test.yml`. It ran before checkout, against an empty workspace, and returned nothing. The key was a constant that never tracked the file it names. The cache froze at whatever the first run saved, and never invalidated when the package list changed.

Moving checkout first makes it resolve. This corrects the invalidation. It does not make the job faster. It does not reduce the flakiness above either. The apt steps took 9s and 6s on `main`, against 7s and 9s here.

One cost comes with it. Any edit to `test.yml` now changes the hash, comments included, so expect a cache miss per change to that file.

## Breaking Changes

None. Nothing changes when the mirror is reachable.
