### PR TITLE
chore: give every workspace crate one version

### DIFF
--- a/crates/hiroz-protocol/Cargo.toml
+++ b/crates/hiroz-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiroz-protocol"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.75"
 authors = ["ZettaScale Technology <contact@zettascale.tech>"]

--- a/crates/hiroz-union/Cargo.toml
+++ b/crates/hiroz-union/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiroz-union"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 description = "hu — plugin platform and TUI for the hiroz ROS 2 ecosystem"
 homepage = "https://github.com/ZettaScaleLabs/hiroz"
@@ -47,4 +47,9 @@ default = ["wasm-plugins"]
 wasm-plugins = ["dep:wasmtime", "dep:wasmtime-wasi"]
 web-plugins = ["wasm-plugins", "dep:axum"]
 ros-interop = []
-humble = []
+# No `humble` feature. It existed here as `humble = []` -- empty, forwarding
+# nothing to hiroz, referenced by no code and no build. `--features humble`
+# therefore selected hiroz's default jazzy while reading as a distro switch.
+# Selecting Humble needs `default-features = false` on the hiroz dependency,
+# which changes this crate's build graph; do that deliberately, not by
+# reviving a no-op flag.

--- a/crates/hiroz/Cargo.toml
+++ b/crates/hiroz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiroz"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 description = "Native Rust ROS 2 implementation using Zenoh"
 license.workspace = true

--- a/crates/rmw-zenoh-rs/Cargo.toml
+++ b/crates/rmw-zenoh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmw-zenoh-rs"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 description = "ROS 2 RMW (ROS Middleware) implementation using Zenoh - Requires ROS 2 Iron or later"
 publish = false


### PR DESCRIPTION
Slice 1 of 4, replacing #301. Each slice is one concern; #301 stays open until all four land.

## What this does

Every workspace crate inherits its version from `[workspace.package]` instead of carrying a literal one.

## What fails without this

`cargo publish --workspace` reads each crate's version from its own manifest, not from the release tag. A crate carrying a literal version is one a release can leave behind: it either republishes a version crates.io already has, failing the job, or ships a number that disagrees with the tag. Four crates carried one.

## Two riders, disclosed

Both are inseparable from the change and are not version hygiene.

| Rider | Effect | Checked |
|---|---|---|
| `sha2` added to `hiroz-union` | unused here; the dependency belongs to the slice that adds `hu plugin install` | no warning by default |
| `humble = []` feature removed from `hiroz-union` | a feature name disappears | no consumer. No workflow or script passes features to `-p hiroz-union`; every `--features humble` targets `hiroz` or `hiroz-tests` |

## Breaking Changes

None. The published version is unchanged.
