### PR TITLE
test(hu): pin the WIT world to its contract

### DIFF
--- a/crates/hiroz-union/src/plugin/install.rs
+++ b/crates/hiroz-union/src/plugin/install.rs
@@ -547,3 +547,83 @@ mod curl_arg_tests {
         assert!(!args.iter().any(|a| a == "-H"), "{args:?}");
     }
 }
+
+/// The WIT world is written out three times — in the `.wit` package
+/// declaration, here, and in the packaging script — and nothing else
+/// reconciles them.
+///
+/// The `.wit` is the contract. If it moves and the other two do not, the host
+/// keeps accepting an index that advertises a world it no longer hosts, and
+/// wasmtime fails later at instantiation with exactly the link error
+/// [`HOST_WIT_WORLD`] exists to prevent. The guard goes decorative at the one
+/// moment it is load-bearing.
+///
+/// The refusal tests elsewhere in this crate cannot see that: they hand-write a
+/// fixture world, so they prove the *comparison* works against a literal, never
+/// that the literal still describes the contract.
+#[cfg(test)]
+mod wit_world_agreement {
+    use super::HOST_WIT_WORLD;
+
+    /// `include_str!` rather than reading at run time: the bytes are the ones
+    /// in the tree this binary was built from, so the test cannot pass against
+    /// a file that is no longer there.
+    const WIT: &str = include_str!("../../wit/v0.1/hu-plugin.wit");
+    const PACKAGING_SCRIPT: &str = include_str!("../../../../scripts/build-hu-release.nu");
+
+    /// The `package …;` line of the WIT file — the actual contract.
+    fn contract_world() -> String {
+        WIT.lines()
+            .find_map(|l| l.trim().strip_prefix("package "))
+            .map(|rest| rest.trim().trim_end_matches(';').to_string())
+            .expect("the WIT file must declare a package")
+    }
+
+    /// The world the packaging script stamps into a published index.
+    fn packaged_world() -> String {
+        PACKAGING_SCRIPT
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("const WIT_WORLD"))
+            .and_then(|rest| {
+                let start = rest.find('"')? + 1;
+                let end = rest[start..].find('"')? + start;
+                Some(rest[start..end].to_string())
+            })
+            .expect("build-hu-release.nu must define const WIT_WORLD")
+    }
+
+    #[test]
+    fn the_host_constant_matches_the_wit_contract() {
+        assert_eq!(
+            contract_world(),
+            HOST_WIT_WORLD,
+            "the WIT package and HOST_WIT_WORLD disagree. The .wit is the \
+             contract: update HOST_WIT_WORLD to match it, or the host will \
+             accept plugins built against a world it no longer hosts."
+        );
+    }
+
+    #[test]
+    fn the_packaging_script_matches_the_wit_contract() {
+        assert_eq!(
+            contract_world(),
+            packaged_world(),
+            "the WIT package and build-hu-release.nu's WIT_WORLD disagree. \
+             Every index this script publishes would advertise the wrong \
+             world, and `hu plugin install` would refuse its own release."
+        );
+    }
+
+    /// Both parsers must actually find something. A silent `None` turned into
+    /// an empty string would make the two assertions above compare "" to "" and
+    /// pass while checking nothing.
+    #[test]
+    fn both_sources_parse_to_something_world_shaped() {
+        for (what, got) in [("wit", contract_world()), ("script", packaged_world())] {
+            assert!(
+                got.starts_with("hu:plugin@") && got.len() > "hu:plugin@".len(),
+                "{what} parsed to {got:?}, which is not a world identifier"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes **G3 of #309** — *"no test covers a version skew between host and plugins"*. #309 lists four gaps between a published release and a real user; this is the third.

This targets `main`. #312 merged the release-pipeline slice, which is where `build-hu-release.nu` comes from.

## What fails without this

Three places carry `hu:plugin@0.1.0`, and nothing reconciles them:

| Location | Role |
|---|---|
| `crates/hiroz-union/wit/v0.1/hu-plugin.wit` — `package hu:plugin@0.1.0;` | the contract |
| `crates/hiroz-union/src/plugin/install.rs` — `HOST_WIT_WORLD` | what the host compares an index against |
| `scripts/build-hu-release.nu` — `const WIT_WORLD` | what a published index advertises |

Bump the `.wit` — the actual contract — and the other two keep the old string. The host then accepts an index that advertises a world it no longer hosts. wasmtime fails later at instantiation, with the link error that `HOST_WIT_WORLD`'s own doc comment says the guard prevents. **The guard is decorative at the one moment it is load-bearing.**

The existing refusal tests cannot see this. They hand-write a fixture world, so they prove the *comparison* works against a literal, never that the literal still describes the contract.

## Evidence in both directions

| Direction | Result |
|---|---|
| as committed | 3 passed, 0 failed |
| `HOST_WIT_WORLD` changed to `hu:plugin@9.9.9` | **FAILED — 2 passed, 1 failed** |
| the script's `WIT_WORLD` changed to `hu:plugin@0.2.0` | **FAILED — 2 passed, 1 failed** |

Each mutation fails exactly the one relevant test, so the detector is specific rather than blanket-red. The script direction is checked separately because a test catching only host-side drift would miss the case that silently publishes wrong indexes.

Those three runs were measured before this branch was rebased onto `main`. The rebase changed no test: this branch is one commit, and it adds 80 lines to `install.rs` and touches nothing else.

A third test asserts that both parsers found something world-shaped. Without it, a parser that returns nothing makes the other two compare empty strings. They would then pass while checking nothing.

## Breaking Changes

None. Tests only.


