### PR TITLE
fix(hu): name the hu target in the default log filter

### DIFF
--- a/crates/hiroz-union/src/core/logger.rs
+++ b/crates/hiroz-union/src/core/logger.rs
@@ -1,14 +1,24 @@
 use tracing_subscriber::{EnvFilter, fmt};
 
+/// Default filter directives when `RUST_LOG` is unset.
+///
+/// `hu` must be listed explicitly: the binary target is named `hu`
+/// (`[[bin]] name = "hu"`), so every `tracing::` call in this crate emits under
+/// the `hu` target. A filter naming only `hiroz` and `zenoh` drops all of them,
+/// which is why the host's schema-discovery and decode warnings were emitted and
+/// then discarded before reaching a terminal.
+pub(crate) fn default_filter(debug: bool) -> &'static str {
+    if debug {
+        "hu=debug,hiroz=debug,zenoh=debug"
+    } else {
+        "hu=info,hiroz=info,zenoh=warn"
+    }
+}
+
 pub fn init_logger(json_mode: bool, debug: bool) {
     // Build filter from RUST_LOG environment variable or default
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        if debug {
-            EnvFilter::new("hiroz=debug,zenoh=debug")
-        } else {
-            EnvFilter::new("hiroz=info,zenoh=warn")
-        }
-    });
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter(debug)));
 
     if json_mode {
         // Structured JSON logs to stderr (for real-time visibility)
@@ -28,5 +38,26 @@ pub fn init_logger(json_mode: bool, debug: bool) {
             .with_ansi(true)
             .with_env_filter(filter)
             .init();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_filter;
+    use tracing_subscriber::EnvFilter;
+
+    // The whole of the `hu` target fix is one string literal, and it is exactly
+    // the kind of line a later edit drops without noticing.
+    #[test]
+    fn defaults_name_the_hu_target_and_parse() {
+        for debug in [false, true] {
+            let directives = default_filter(debug);
+            assert!(
+                directives.contains("hu="),
+                "default filter for debug={debug} does not name the `hu` target: {directives}"
+            );
+            EnvFilter::try_new(directives)
+                .unwrap_or_else(|e| panic!("default filter {directives:?} does not parse: {e}"));
+        }
     }
 }


### PR DESCRIPTION
Slice 1 of 5, splitting #311. Independent of the other four.

## What this does

Adds the `hu` target to the default log filter.

## What fails without this

The binary target is named `hu`, so every `tracing::` call in `hiroz-union` emits under the `hu` target. The default filter named only `hiroz` and `zenoh`. With `RUST_LOG` unset, the host emitted its own warnings and then discarded them.

| | before | after |
|---|---|---|
| default filter, quiet | `hiroz=info,zenoh=warn` | `hu=info,hiroz=info,zenoh=warn` |
| default filter, `--debug` | `hiroz=debug,zenoh=debug` | `hu=debug,hiroz=debug,zenoh=debug` |
| a host warning, `RUST_LOG` unset | emitted, then dropped | reaches the terminal |
| `RUST_LOG` set | honoured | honoured — unchanged |

The whole fix is one string literal, which is the kind of line a later edit drops without noticing. `defaults_name_the_hu_target_and_parse` asserts both defaults name the target and parse.

## Breaking changes

None. A user who sets `RUST_LOG` sees no change.
