### PR TITLE
fix(hu): use axum 0.8 wildcard route syntax in hu web

### DIFF
--- a/crates/hiroz-union/src/modes/web.rs
+++ b/crates/hiroz-union/src/modes/web.rs
@@ -41,6 +41,18 @@ mod inner {
         plugins: Mutex<Vec<WasmPlugin>>,
     }
 
+    /// Split out from `run_web_mode` so a test can build it without a router,
+    /// a Zenoh session or a bound socket. `Router::route` validates path
+    /// syntax by **panicking at run time**, not at compile time — the axum 0.7
+    /// form `*path` compiles cleanly and then aborts `hu web` on startup. That
+    /// shipped unnoticed because `web-plugins` was never built in CI.
+    fn build_router(state: Arc<WebState>) -> Router {
+        Router::new()
+            .route("/plugins/{name}/{*path}", any(handle_plugin_request))
+            .route("/plugins/{name}", any(handle_plugin_request_root))
+            .with_state(state)
+    }
+
     pub async fn run_web_mode(
         core: Arc<CoreEngine>,
         port: u16,
@@ -59,10 +71,7 @@ mod inner {
             plugins: Mutex::new(plugins),
         });
 
-        let app = Router::new()
-            .route("/plugins/{name}/*path", any(handle_plugin_request))
-            .route("/plugins/{name}", any(handle_plugin_request_root))
-            .with_state(state);
+        let app = build_router(state);
 
         // Bind to loopback by default so the plugin HTTP surface is not exposed
         // on all interfaces. Set `HU_WEB_BIND` (e.g. `0.0.0.0`) to opt into
@@ -136,6 +145,24 @@ mod inner {
                         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
                 }
             },
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Regression: the routes used axum 0.7 wildcard syntax (`*path`)
+        /// against axum 0.8. That compiles cleanly and panics the moment
+        /// `hu web` starts, so it shipped unnoticed while `web-plugins` was
+        /// never built in CI. Building the router IS the check — wrong path
+        /// syntax panics here.
+        #[test]
+        fn router_paths_are_valid_for_this_axum_version() {
+            let state = Arc::new(WebState {
+                plugins: Mutex::new(Vec::new()),
+            });
+            let _ = build_router(state);
         }
     }
 }


### PR DESCRIPTION
Slice 2 of 5, splitting #311. Independent of the other four.

## What this does

Uses axum 0.8 wildcard route syntax in `hu web`, and adds a test that builds the router.

## What fails without this

The routes used the axum 0.7 form `*path`. `Router::route` validates path syntax by **panicking at run time**, not at compile time.

| | before | after |
|---|---|---|
| `hu web` startup | panics: `Path segments must not start with '*'` | serves |
| compile | clean | clean — unchanged |

The command was documented and shipped, and nothing caught it, because `web-plugins` is not a default feature and CI never compiled it.

Router construction moves into `build_router` so a test can exercise it without a Zenoh session or a bound socket. Building the router **is** the check: wrong path syntax panics there.

> [!IMPORTANT]
> The test only exists under `--features web-plugins`. Without that flag the same `cargo test` invocation reports `0 passed; 13 filtered out` and exits 0. Any CI job meant to cover this must pass the feature, or it is green over nothing.

## Breaking changes

None.
