### PR TITLE
chore: release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiroz"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "clap",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-cdr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-codegen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-msgs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1897,14 +1897,14 @@ dependencies = [
 
 [[package]]
 name = "hiroz-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zenoh",
 ]
 
 [[package]]
 name = "hiroz-py"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "flume",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-schema"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hiroz",
  "hiroz-cdr",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "hiroz-union"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "rmw-zenoh-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Native Rust ROS 2 implementation using Zenoh"
 homepage = "https://github.com/ZettaScaleLabs/hiroz"
@@ -38,15 +38,15 @@ default-members = ["crates/hiroz", "crates/hiroz-codegen"]
 
 [workspace.dependencies]
 # Workspace members
-hiroz = { version = "0.1.0", path = "crates/hiroz" }
-hiroz-codegen = { version = "0.1.0", path = "crates/hiroz-codegen" }
-hiroz-protocol = { version = "0.1.0", path = "crates/hiroz-protocol" }
-rmw-zenoh-rs = { version = "0.1.0", path = "crates/rmw-zenoh-rs" }
-hiroz-schema = { version = "0.1.0", path = "crates/hiroz-schema" }
+hiroz = { version = "0.2.0", path = "crates/hiroz" }
+hiroz-codegen = { version = "0.2.0", path = "crates/hiroz-codegen" }
+hiroz-protocol = { version = "0.2.0", path = "crates/hiroz-protocol" }
+rmw-zenoh-rs = { version = "0.2.0", path = "crates/rmw-zenoh-rs" }
+hiroz-schema = { version = "0.2.0", path = "crates/hiroz-schema" }
 
 # Serialization
-hiroz-cdr = { version = "0.1.0", path = "crates/hiroz-cdr" }
-hiroz-derive = { version = "0.1.0", path = "crates/hiroz-derive" }
+hiroz-cdr = { version = "0.2.0", path = "crates/hiroz-cdr" }
+hiroz-derive = { version = "0.2.0", path = "crates/hiroz-derive" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"

--- a/crates/hiroz-msgs/Cargo.toml
+++ b/crates/hiroz-msgs/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = { workspace = true, optional = true }
 byteorder = { workspace = true }
 
 [build-dependencies]
-hiroz-codegen = { version = "0.1", path = "../hiroz-codegen" }
+hiroz-codegen = { version = "0.2", path = "../hiroz-codegen" }
 anyhow = { workspace = true }
 glob = { workspace = true }
 

--- a/crates/hiroz/Cargo.toml
+++ b/crates/hiroz/Cargo.toml
@@ -46,7 +46,7 @@ pyo3 = { workspace = true, optional = true }
 hiroz-cdr = { workspace = true }
 hiroz-codegen = { workspace = true, optional = true }
 hiroz-derive = { workspace = true }
-hiroz-protocol = { path = "../hiroz-protocol", version = "0.1.0", default-features = false, features = [
+hiroz-protocol = { path = "../hiroz-protocol", version = "0.2.0", default-features = false, features = [
   "std",
 ] }
 hiroz-schema = { workspace = true }


### PR DESCRIPTION
`hu` and its WASM plugins are downloadable and usable, which is a feature addition. The workspace moves to 0.2.0.

## Why not 0.1.0

`hiroz`, `hiroz-cdr`, `hiroz-protocol` and `hiroz-schema` are already published on crates.io at 0.1.0. `publish-crates` runs `cargo publish --workspace` on any tag without a `-` in it, so a `v0.1.0` tag would:

| Stage | Result |
|---|---|
| build and publish the release | succeeds — the assets are correct |
| `cargo publish --workspace` | **fails** — four crates already exist at 0.1.0 |
| `withdraw-release` | does **not** fire — it keys on the download test, which passed |

The release would be public and correct, and the run would be red, with no automatic withdrawal.

## What this changes

| Item | From | To |
|---|---|---|
| `[workspace.package] version` | 0.1.0 | 0.2.0 |
| seven workspace-member pins in `[workspace.dependencies]` | 0.1.0 | 0.2.0 |
| the inline `hiroz-protocol` pin in `crates/hiroz` | 0.1.0 | 0.2.0 |
| the eleven workspace entries in `Cargo.lock` | 0.1.0 | 0.2.0 |

The member pins are the part worth checking. Left at 0.1.0, a published `hiroz` 0.2.0 would resolve its own siblings to the previously published 0.1.0 crates rather than to the ones released beside it.

## Evidence

The release pipeline was rehearsed on `main` at `29d2688e1` with tag `v0.1.0-smoke-test` (run 32556960868, success). It published a release carrying `hu` for three targets, both `.wasm` plugins, the plugin index, `install-hu.sh` and `SHA256SUMS`, then installed from those published URLs and reproduced every documented command against the result. The tag and release were deleted afterwards.

`scripts/test-release-version-semantics.sh` passes 56/0 after this change.

## Breaking changes

None. A version bump only.