### PR TITLE
fix(release): give the rehearsal tag a message

### DIFF
--- a/scripts/test-release-version-semantics.sh
+++ b/scripts/test-release-version-semantics.sh
@@ -357,6 +357,16 @@ grep_must_not "$GH" "the withdraw job does not test equality with failure" \
     "needs.smoke-test-release-install.result == 'failure'"
 grep_must     "$GH" "the download test waits for the promotion" 'needs: \[publish-release\]'
 grep_must     "$GH" "crates.io is gated behind the download test" 'needs: \[smoke-test-release-install\]'
+
+# The rehearsal script must give its tag a message. A bare `git tag` produces a
+# SIGNED tag for anyone with `tag.gpgsign = true`, and a signed tag needs a
+# message -- so the script died with `fatal: no tag message?` before pushing
+# anything, on exactly the machines that cut releases. RELEASING.md names this
+# script as the documented rehearsal, so that failure removed the only
+# documented way to test a release without cutting one.
+RW="scripts/test-release-workflow.nu"
+grep_must     "$RW" "the rehearsal tag carries a message" '\^git tag -a -m'
+grep_must_not "$RW" "the rehearsal does not create a bare tag" '\^git tag \$tag$'
 echo
 echo "-- $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-release-workflow.nu
+++ b/scripts/test-release-workflow.nu
@@ -73,7 +73,13 @@ def main [
     log-header "Release workflow smoke test" $tag
 
     log-step $"Creating tag ($tag)"
-    ^git tag $tag
+    # `-a -m`, not a bare `git tag`. A user with `tag.gpgsign = true` in their
+    # git config gets a SIGNED tag from the bare form, and a signed tag needs a
+    # message -- so the script died with `fatal: no tag message?` before pushing
+    # anything, on the very machine that cuts releases. This form works either
+    # way: with signing configured the tag is signed and carries a message, and
+    # without it the tag is annotated.
+    ^git tag -a -m $"Release workflow rehearsal for ($tag). Temporary; deleted on cleanup." $tag
 
     log-step $"Pushing tag ($tag) → ($REPO)"
     ^git push origin $tag


### PR DESCRIPTION
`scripts/test-release-workflow.nu` created its tag with a bare `git tag $tag`.

## What fails without this

A user with `tag.gpgsign = true` in their git config gets a **signed** tag from that form, and a signed tag needs a message. The script dies before pushing anything:

```
→ Creating tag v0.1.0-smoke-test
fatal: no tag message?
```

`RELEASING.md` names this script as the documented way to rehearse a release. The failure therefore removed the only documented way to exercise the release pipeline without cutting a release. It fails on exactly the machines that cut releases, because signing tags is a reasonable default there.

| | before | after |
|---|---|---|
| `tag.gpgsign` unset | annotated tag, works | annotated tag, works |
| `tag.gpgsign = true` | **`fatal: no tag message?`, no tag created** | signed tag with a message |

`-a -m` works either way. With signing configured the tag is signed and carries a message; without it the tag is annotated.

## Evidence

Measured on a machine with `tag.gpgsign = true`:

| Form | Result |
|---|---|
| `git tag <name>` | `fatal: no tag message?` — no tag created |
| `git tag -a -m "..." <name>` | annotated tag object created |

## The guard

Two assertions in `scripts/test-release-version-semantics.sh`, which `ci.yml` runs on every pull request. Reverting the line:

| | passed | failed |
|---|---|---|
| as committed | 58 | 0 |
| with the bare `git tag` restored | 56 | **2** |

Both guards name what they found: the missing `-a -m` form, and the returning bare form.

## Breaking changes

None. The tag this produces is annotated rather than lightweight, which the rehearsal deletes on cleanup either way.