### PR TITLE
fix(rmw-zenoh-rs): publish on the DDS-mangled type name, as the wire requires

### DIFF
--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -107,6 +107,22 @@ jobs:
             --include-filter "$TEST_FILTER" \
             --exclude-filter "test_count_matched|test_events"
 
+      # The RMW graph APIs must report the ROS type name, not the wire form.
+      # The graph stores the wire form, so every RMW query demangles on the way
+      # out, as rmw_zenoh_cpp does. Only this workflow builds rmw_zenoh_rs, so
+      # only this workflow can catch a regression here.
+      - name: Graph queries report the ROS type name
+        shell: bash
+        run: |
+          set -o pipefail
+          source /opt/ros/jazzy/setup.bash
+          # The workspace overlay is what puts rmw_zenoh_rs on the RMW search
+          # path. Without it the talker cannot load the RMW at all.
+          source $GITHUB_WORKSPACE/ws/install/setup.bash
+          set -u
+          cd hiroz
+          nu scripts/test-ros.nu --distro jazzy graph-type-names
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/crates/hiroz-codegen/src/generator/rust.rs
+++ b/crates/hiroz-codegen/src/generator/rust.rs
@@ -1,3 +1,4 @@
+use hiroz_schema::type_name::dds_from_namespace;
 use std::collections::HashSet;
 
 use anyhow::Result;
@@ -933,7 +934,7 @@ fn generate_message_type_info(
     ctx: &GenerationContext,
 ) -> TokenStream {
     let name_ident = format_ident!("{}", name);
-    let type_name = format!("{}::msg::dds_::{}_", package, name);
+    let type_name = dds_from_namespace(&format!("{package}::msg"), name);
     let schema_type_name = format!("{}/msg/{}", package, name);
     let hash_str = type_hash.to_rihs_string();
     let schema_field_tokens: Vec<TokenStream> = fields
@@ -1233,7 +1234,8 @@ pub fn generate_service_impl(srv: &ResolvedService) -> Result<TokenStream> {
     let name = format_ident!("{}", srv.parsed.name);
     let request_type = format_ident!("{}Request", srv.parsed.name);
     let response_type = format_ident!("{}Response", srv.parsed.name);
-    let service_type_name = format!("{}::srv::dds_::{}_", srv.parsed.package, srv.parsed.name);
+    let service_type_name =
+        dds_from_namespace(&format!("{}::srv", srv.parsed.package), &srv.parsed.name);
     let hash_str = srv.type_hash.to_rihs_string();
 
     Ok(quote! {
@@ -1264,25 +1266,25 @@ pub fn generate_action_impl(action: &crate::types::ResolvedAction) -> Result<Tok
     let goal_type = format_ident!("{}Goal", action.parsed.name);
     let result_type = format_ident!("{}Result", action.parsed.name);
     let feedback_type = format_ident!("{}Feedback", action.parsed.name);
-    let action_type_name = format!(
-        "{}::action::dds_::{}_",
-        action.parsed.package, action.parsed.name
-    );
+    let action_ns = format!("{}::action", action.parsed.package);
+    let action_type_name = dds_from_namespace(&action_ns, &action.parsed.name);
     let hash_str = action.type_hash.to_rihs_string();
 
-    // Type names for action-related services and messages (ROS2 format with underscore)
-    let send_goal_type_name = format!(
-        "{}::action::dds_::{}_SendGoal_",
-        action.parsed.package, action.parsed.name
+    // The three action-related interfaces decorate the action's own name. They
+    // therefore use the same mangling rule, with a decorated name.
+    let send_goal_type_name =
+        dds_from_namespace(&action_ns, &format!("{}_SendGoal", action.parsed.name));
+    let get_result_type_name =
+        dds_from_namespace(&action_ns, &format!("{}_GetResult", action.parsed.name));
+    let feedback_msg_type_name = dds_from_namespace(
+        &action_ns,
+        &format!("{}_FeedbackMessage", action.parsed.name),
     );
-    let get_result_type_name = format!(
-        "{}::action::dds_::{}_GetResult_",
-        action.parsed.package, action.parsed.name
-    );
-    let feedback_msg_type_name = format!(
-        "{}::action::dds_::{}_FeedbackMessage_",
-        action.parsed.package, action.parsed.name
-    );
+
+    // Every action uses these two fixed interfaces. Mangle them through the
+    // same rule, rather than writing them out as literals.
+    let cancel_goal_type_name = dds_from_namespace("action_msgs::srv", "CancelGoal");
+    let status_type_name = dds_from_namespace("action_msgs::msg", "GoalStatusArray");
 
     // Get type hashes from resolved action service hashes (not the Goal/Result/Feedback hashes)
     let send_goal_hash_str = action.send_goal_hash.to_rihs_string();
@@ -1321,7 +1323,7 @@ pub fn generate_action_impl(action: &crate::types::ResolvedAction) -> Result<Tok
 
             fn cancel_goal_type_info() -> ::hiroz::entity::TypeInfo {
                 ::hiroz::entity::TypeInfo::new(
-                    "action_msgs::srv::dds_::CancelGoal_",
+                    #cancel_goal_type_name,
                     ::hiroz::entity::TypeHash::from_rihs_string(#cancel_goal_hash_str)
                         .expect("Invalid RIHS hash")
                 )
@@ -1337,7 +1339,7 @@ pub fn generate_action_impl(action: &crate::types::ResolvedAction) -> Result<Tok
 
             fn status_type_info() -> ::hiroz::entity::TypeInfo {
                 ::hiroz::entity::TypeInfo::new(
-                    "action_msgs::msg::dds_::GoalStatusArray_",
+                    #status_type_name,
                     ::hiroz::entity::TypeHash::from_rihs_string(#status_hash_str)
                         .expect("Invalid RIHS hash")
                 )

--- a/crates/hiroz-codegen/src/protobuf_generator.rs
+++ b/crates/hiroz-codegen/src/protobuf_generator.rs
@@ -1,3 +1,4 @@
+use hiroz_schema::type_name::dds_from_namespace;
 use anyhow::{Context, Result};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -292,7 +293,8 @@ impl ProtobufMessageGenerator {
             );
 
             // ROS2 type name
-            let ros2_type_name = format!("{}::msg::dds_::{}_", package, msg_name);
+            let ros2_type_name =
+                dds_from_namespace(&format!("{package}::msg"), msg_name);
 
             // Get hash
             let hash = msg.type_hash.to_rihs_string();

--- a/crates/hiroz-derive/Cargo.toml
+++ b/crates/hiroz-derive/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro = true
 syn = { workspace = true, features = ["full", "parsing", "extra-traits"] }
 quote.workspace = true
 proc-macro2.workspace = true
+hiroz-schema = { workspace = true }

--- a/crates/hiroz-derive/src/lib.rs
+++ b/crates/hiroz-derive/src/lib.rs
@@ -410,8 +410,13 @@ fn parse_canonical_type_name(type_name: &str) -> syn::Result<(String, String, St
 }
 
 fn canonical_to_dds_name(type_name: &str) -> syn::Result<String> {
+    // Validate first, so that the caller gets this crate's own error message.
+    // Then mangle through the shared rule, rather than a second copy of it.
     let (package, kind, name) = parse_canonical_type_name(type_name)?;
-    Ok(format!("{package}::{kind}::dds_::{name}_"))
+    Ok(hiroz_schema::type_name::dds_from_namespace(
+        &format!("{package}::{kind}"),
+        &name,
+    ))
 }
 
 /// Generate extraction code for a single field.

--- a/crates/hiroz-protocol/Cargo.toml
+++ b/crates/hiroz-protocol/Cargo.toml
@@ -18,6 +18,7 @@ no-type-hash = []              # ROS 2 Humble doesn't support type hashing
 
 [dependencies]
 zenoh = { version = "1.9.0", default-features = false }
+hiroz-schema = { workspace = true }
 
 [dev-dependencies]
 zenoh = { version = "1.9.0", default-features = false }

--- a/crates/hiroz-protocol/src/format/rmw_zenoh.rs
+++ b/crates/hiroz-protocol/src/format/rmw_zenoh.rs
@@ -25,6 +25,22 @@ pub const EMPTY_TOPIC_TYPE: &str = "EMPTY_TOPIC_TYPE";
 /// Placeholder for empty topic hash.
 pub const EMPTY_TOPIC_HASH: &str = "EMPTY_TOPIC_HASH";
 
+/// The DDS type name for an rmw_zenoh key expression, e.g.
+/// `std_msgs::msg::dds_::String_`.
+///
+/// [`hiroz_schema::type_name`] owns this rule for the whole workspace.
+/// `hiroz-codegen`, `hiroz-derive` and the dynamic-schema path all call the
+/// same function, so they cannot drift apart.
+pub use hiroz_schema::type_name::dds_from_namespace as dds_type_name;
+
+/// Recover the ROS type name from the wire form, for an RMW graph query.
+///
+/// This is the **strict** inverse. It matches `_demangle_if_ros_type` in
+/// `rmw_zenoh_cpp`'s `graph_cache.cpp` byte for byte, which an RMW boundary
+/// requires. Use [`hiroz_schema::ros_from_dds`] instead when the caller looks
+/// the result up in the schema registry.
+pub use hiroz_schema::type_name::ros_from_dds_strict as ros_type_name;
+
 /// rmw_zenoh compatible backend.
 pub struct RmwZenohFormatter;
 

--- a/crates/hiroz-protocol/tests/type_name_agreement.rs
+++ b/crates/hiroz-protocol/tests/type_name_agreement.rs
@@ -1,0 +1,194 @@
+//! The library and `rmw-zenoh-rs` must derive the same topic key expression.
+//!
+//! A hiroz library node and a ROS 2 node running `rmw_zenoh_rs` publish on a key
+//! expression built from the type name. If the two derive that name differently,
+//! they match no topic and exchange nothing. Neither side reports an error.
+//!
+//! These tests pin the derivation against the form measured on the wire from
+//! upstream `rmw_zenoh_cpp`.
+
+use hiroz_protocol::{
+    entity::{EndpointEntity, EndpointKind, NodeEntity, TypeHash, TypeInfo},
+    // `topic_key_expr` is an associated function on the KeyExprFormatter trait,
+    // so the trait must be in scope here.
+    format::{rmw_zenoh::dds_type_name, rmw_zenoh::RmwZenohFormatter, KeyExprFormatter},
+    qos::QosProfile,
+};
+use hiroz_schema::type_name::service_from_response;
+
+/// The exact string upstream `rmw_zenoh_cpp` was measured to declare.
+///
+/// Recorded from `ros-jazzy-rmw-zenoh-cpp` running `demo_nodes_cpp talker`, with
+/// a raw zenoh subscriber on `**` attached to its router:
+///
+/// ```text
+/// 0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c74...
+/// ```
+const WIRE_TYPE_NAME: &str = "std_msgs::msg::dds_::String_";
+
+fn zid() -> zenoh::session::ZenohId {
+    "1234567890abcdef1234567890abcdef".parse().unwrap()
+}
+
+/// An endpoint of `kind` on `topic`, carrying `type_name`.
+fn endpoint(kind: EndpointKind, topic: &str, type_name: &str) -> EndpointEntity {
+    let node = NodeEntity::new(
+        0,
+        zid(),
+        0,
+        "talker".to_string(),
+        "/".to_string(),
+        String::new(),
+    );
+    EndpointEntity {
+        id: 1,
+        node: Some(node),
+        kind,
+        topic: topic.to_string(),
+        type_info: Some(TypeInfo::new(type_name, TypeHash::zero())),
+        qos: QosProfile::default(),
+    }
+}
+
+/// Build the topic key expression for `/chatter` carrying `type_name`.
+fn chatter_key(type_name: &str) -> String {
+    let zid: zenoh::session::ZenohId = "1234567890abcdef1234567890abcdef".parse().unwrap();
+    let node = NodeEntity::new(
+        0,
+        zid,
+        0,
+        "talker".to_string(),
+        "/".to_string(),
+        String::new(),
+    );
+    let entity = EndpointEntity {
+        id: 1,
+        node: Some(node),
+        kind: EndpointKind::Publisher,
+        topic: "chatter".to_string(),
+        type_info: Some(TypeInfo::new(type_name, TypeHash::zero())),
+        qos: QosProfile::default(),
+    };
+    RmwZenohFormatter::topic_key_expr(&entity)
+        .unwrap()
+        .as_str()
+        .to_string()
+}
+
+/// A hiroz library node and a `rmw_zenoh_rs` node must publish `std_msgs/String`
+/// on the SAME key expression, or they cannot hear each other at all.
+///
+/// The library agrees with the measured wire form. Before this test,
+/// `rmw-zenoh-rs` derived `std_msgs/msg/String` instead. It then published on
+///
+/// ```text
+/// 0/chatter/std_msgs/msg/String/RIHS01_df668c74...
+/// ```
+///
+/// Same domain, same topic, byte-identical type hash. Only the type-name
+/// segment differed, and the two stacks were silently deaf to each other.
+#[test]
+fn library_and_rmw_derive_the_same_topic_key() {
+    // What rmw-zenoh-rs derives from the C++ typesupport for this type:
+    // message_namespace_ = "std_msgs::msg", message_name_ = "String".
+    let rmw_type_name = dds_type_name("std_msgs::msg", "String");
+
+    assert_eq!(
+        rmw_type_name, WIRE_TYPE_NAME,
+        "rmw-zenoh-rs derives a different type name than the library, and than \
+         rmw_zenoh_cpp puts on the wire"
+    );
+
+    // The whole key expression must agree, not only the segment.
+    assert_eq!(
+        chatter_key(&rmw_type_name),
+        chatter_key(WIRE_TYPE_NAME),
+        "topic key expressions disagree"
+    );
+    assert_eq!(
+        chatter_key(WIRE_TYPE_NAME),
+        format!("0/chatter/{WIRE_TYPE_NAME}/{}", TypeHash::zero()),
+    );
+}
+
+/// The service key uses the same mangling on the request and response pair.
+///
+/// This calls `service_from_response`, which is the rule the production path
+/// uses. An earlier version of this test re-implemented the suffix strip, so it
+/// could not have caught a regression in that rule.
+#[test]
+fn service_type_name_is_dds_mangled() {
+    let response = dds_type_name("example_interfaces::srv", "AddTwoInts_Response");
+    assert_eq!(
+        response,
+        "example_interfaces::srv::dds_::AddTwoInts_Response_"
+    );
+
+    let service = service_from_response(&response).expect("a response name yields a service name");
+    assert_eq!(service, "example_interfaces::srv::dds_::AddTwoInts_");
+}
+
+/// The liveliness token must carry the same mangled name as the topic key.
+///
+/// Both consume `get_type_info()`, so the fix corrects the token by
+/// construction. This test states that rather than leaving it to inference: a
+/// token carrying the slash form would make hiroz and `rmw_zenoh_rs` invisible
+/// to each other in the graph, even once their topic keys agreed.
+#[test]
+fn the_liveliness_token_carries_the_wire_type_name() {
+    let entity = endpoint(EndpointKind::Publisher, "chatter", WIRE_TYPE_NAME);
+    let ke = RmwZenohFormatter::liveliness_key_expr(&entity, &zid()).unwrap();
+    let ke = ke.as_str();
+
+    assert!(
+        ke.contains(WIRE_TYPE_NAME),
+        "the liveliness token does not carry the wire type name: {ke}"
+    );
+    assert!(
+        !ke.contains("std_msgs/msg/String"),
+        "the liveliness token still carries the slash form: {ke}"
+    );
+}
+
+/// A service key expression uses the mangled service name.
+///
+/// The end-to-end runs covered `std_msgs/String` only, so this pins the service
+/// path at the formatter instead of leaving it untested.
+#[test]
+fn a_service_key_expression_uses_the_mangled_name() {
+    let response = dds_type_name("example_interfaces::srv", "AddTwoInts_Response");
+    let service = service_from_response(&response).expect("a service name");
+
+    let entity = endpoint(EndpointKind::Service, "add_two_ints", &service);
+    let ke = RmwZenohFormatter::topic_key_expr(&entity).unwrap();
+
+    assert_eq!(
+        ke.as_str(),
+        format!("0/add_two_ints/{service}/{}", TypeHash::zero()),
+    );
+    assert!(service.starts_with("example_interfaces::srv::dds_::"));
+}
+
+/// An action's three interfaces use the same mangling as everything else.
+///
+/// No end-to-end run exercised an action, so this pins the names the code
+/// generator bakes in against the shared rule.
+#[test]
+fn the_action_interfaces_use_the_same_mangling() {
+    let ns = "action_tutorials_interfaces::action";
+    for (suffix, expected) in [
+        ("_SendGoal", "Fibonacci_SendGoal_"),
+        ("_GetResult", "Fibonacci_GetResult_"),
+        ("_FeedbackMessage", "Fibonacci_FeedbackMessage_"),
+    ] {
+        let name = dds_type_name(ns, &format!("Fibonacci{suffix}"));
+        assert_eq!(name, format!("{ns}::dds_::{expected}"));
+
+        let entity = endpoint(EndpointKind::Publisher, "fibonacci", &name);
+        let ke = RmwZenohFormatter::topic_key_expr(&entity).unwrap();
+        assert!(
+            ke.as_str().contains(&name),
+            "action key lost the name: {ke}"
+        );
+    }
+}

--- a/crates/hiroz-py/Cargo.toml
+++ b/crates/hiroz-py/Cargo.toml
@@ -19,6 +19,7 @@ lyrical = ["hiroz/lyrical"]
 [dependencies]
 pyo3 = { workspace = true }
 hiroz = { path = "../hiroz", default-features = false }
+hiroz-schema = { workspace = true }
 hiroz-cdr = { workspace = true }
 hiroz-msgs = { path = "../hiroz-msgs", features = [
   "python_registry",

--- a/crates/hiroz-py/src/utils.rs
+++ b/crates/hiroz-py/src/utils.rs
@@ -23,5 +23,5 @@ pub(crate) fn python_type_to_rust_type(python_type: &str) -> String {
     let msg_name = parts[2];
 
     // Convert to Rust format: package::category::dds_::MessageName_
-    format!("{}::{}::dds_::{}_", package, category, msg_name)
+    hiroz_schema::type_name::dds_from_namespace(&format!("{package}::{category}"), msg_name)
 }

--- a/crates/hiroz-schema/src/lib.rs
+++ b/crates/hiroz-schema/src/lib.rs
@@ -13,12 +13,17 @@
 mod hash;
 mod type_description;
 mod type_id;
+pub mod type_name;
 
 pub use hash::{calculate_hash, to_ros2_json};
 pub use type_description::{
     FieldDescription, FieldTypeDescription, TypeDescription, TypeDescriptionMsg, to_hash_version,
 };
 pub use type_id::TypeId;
+pub use type_name::{
+    KINDS, dds_from_canonical, dds_from_namespace, ros_from_dds, ros_from_dds_strict,
+    service_from_response, split_canonical,
+};
 
 /// RIHS01 type hash (32 bytes)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/hiroz-schema/src/type_name.rs
+++ b/crates/hiroz-schema/src/type_name.rs
@@ -1,0 +1,129 @@
+//! The mapping between the two spellings of a ROS type name.
+//!
+//! ROS names a type `std_msgs/msg/String`. The DDS wire spells the same type
+//! `std_msgs::msg::dds_::String_`. Every rmw_zenoh key expression and every
+//! liveliness token uses that second form.
+//!
+//! Both forms appear throughout hiroz. A disagreement between two derivations
+//! of them is not a cosmetic problem. Two nodes that mangle differently publish
+//! on different key expressions. They then never see each other, and neither
+//! reports an error.
+//!
+//! This module holds that rule once. It lives in `hiroz-schema` for two
+//! reasons. This crate already owns the canonical form, because
+//! `TypeDescription::type_name` is `std_msgs/msg/String`. This crate is also a
+//! leaf, so the runtime, the code generator and the derive macro all reach it.
+
+/// The three interface kinds a canonical ROS type name can carry.
+pub const KINDS: [&str; 3] = ["msg", "srv", "action"];
+
+const DDS_SEGMENT: &str = "dds_::";
+
+/// Build the DDS form from a namespace that is already joined with `::` and a
+/// bare type name: `("std_msgs::msg", "String")` gives
+/// `std_msgs::msg::dds_::String_`.
+///
+/// The C++ typesupport hands `rmw-zenoh-rs` this shape at runtime, because
+/// `message_namespace_` and `message_name_` arrive separately. An empty
+/// namespace is legal, and gives `dds_::String_`.
+///
+/// The action sub-types also use this function. Pass the decorated name, for
+/// example `("my_pkg::action", "Fib_SendGoal")`.
+pub fn dds_from_namespace(namespace: &str, name: &str) -> String {
+    if namespace.is_empty() {
+        format!("{DDS_SEGMENT}{name}_")
+    } else {
+        format!("{namespace}::{DDS_SEGMENT}{name}_")
+    }
+}
+
+/// Split a canonical ROS type name into `(package, kind, name)`.
+///
+/// This function returns `None` unless the input has exactly three
+/// `/`-separated parts. Its middle part must be one of [`KINDS`]. A caller that
+/// supports fewer kinds checks the returned kind itself, so that each caller
+/// gives its own error message.
+pub fn split_canonical(canonical: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = canonical.split('/');
+    let (package, kind, name) = (parts.next()?, parts.next()?, parts.next()?);
+    if parts.next().is_some() || !KINDS.contains(&kind) {
+        return None;
+    }
+    Some((package, kind, name))
+}
+
+/// Build the DDS form from a canonical name: `std_msgs/msg/String` gives
+/// `std_msgs::msg::dds_::String_`.
+///
+/// This function returns `None` when the input is not a canonical three-part
+/// name. The caller then decides whether that is an error, or a value to pass
+/// through.
+pub fn dds_from_canonical(canonical: &str) -> Option<String> {
+    let (package, kind, name) = split_canonical(canonical)?;
+    Some(dds_from_namespace(&format!("{package}::{kind}"), name))
+}
+
+/// Derive a service's DDS type name from its response type's DDS type name:
+/// `example_interfaces::srv::dds_::AddTwoInts_Response_` gives
+/// `example_interfaces::srv::dds_::AddTwoInts_`.
+///
+/// The rmw_zenoh key for a service names the service. A typesupport gives only
+/// the response type. This function returns `None` when the input does not end
+/// in the response suffix, so the caller chooses whether that is an error.
+pub fn service_from_response(response_dds: &str) -> Option<String> {
+    response_dds
+        .strip_suffix("_Response_")
+        .map(|stem| format!("{stem}_"))
+}
+
+/// Recover the canonical form from the DDS form, exactly as `rmw_zenoh_cpp`
+/// does.
+///
+/// This is a direct port of `_demangle_if_ros_type` in `rmw_zenoh_cpp`'s
+/// `graph_cache.cpp`. It keeps both bail-out arms. It returns unchanged an
+/// input with no trailing `_`, and an input with no `dds_::` segment.
+///
+/// **Use this function at an RMW boundary.** There, the code must match the
+/// reference implementation byte for byte. Use [`ros_from_dds`] instead when
+/// the goal is to find a schema.
+pub fn ros_from_dds_strict(dds: &str) -> String {
+    let Some(stem) = dds.strip_suffix('_') else {
+        return dds.to_string();
+    };
+    let Some(pos) = stem.find(DDS_SEGMENT) else {
+        return dds.to_string();
+    };
+    let namespace = stem[..pos].replace("::", "/");
+    let name = &stem[pos + DDS_SEGMENT.len()..];
+    format!("{namespace}{name}")
+}
+
+/// Recover the canonical form from the DDS form, tolerating a name whose
+/// `dds_::` segment is missing.
+///
+/// [`ros_from_dds_strict`] returns `rcl_interfaces::msg::ParameterEvent_`
+/// unchanged, because `rmw_zenoh_cpp` returns it unchanged. That is correct at
+/// an RMW boundary. It is wrong when the caller looks the result up in the
+/// schema registry. That caller needs `rcl_interfaces/msg/ParameterEvent`, and
+/// a name that stays mangled fails to resolve.
+///
+/// So this function applies the strict rule first. It falls back to replacing a
+/// bare `::<kind>::` separator only when the strict rule declines. The two
+/// functions agree on every name that carries a `dds_::` segment. They differ
+/// only on the names that the strict rule must leave alone.
+///
+/// The fallback also trims a trailing underscore from **any** name it sees,
+/// including a name that is not a ROS type. This behaviour is deliberate. This
+/// path has always done it, and its callers look a name up in the schema
+/// registry. There, a stray underscore decides a hit or a miss.
+pub fn ros_from_dds(dds: &str) -> String {
+    let strict = ros_from_dds_strict(dds);
+    if strict != dds {
+        return strict;
+    }
+    let mut out = dds.to_string();
+    for kind in KINDS {
+        out = out.replace(&format!("::{kind}::"), &format!("/{kind}/"));
+    }
+    out.trim_end_matches('_').to_string()
+}

--- a/crates/hiroz-schema/tests/type_name.rs
+++ b/crates/hiroz-schema/tests/type_name.rs
@@ -1,0 +1,125 @@
+//! The mapping between the two spellings of a ROS type name.
+//!
+//! `hiroz_schema::type_name` holds that rule once, for the whole workspace. If
+//! two derivations of it disagree, two nodes publish on different key
+//! expressions and never see each other. Neither one reports an error.
+//!
+//! These tests pin the forward rule, both inverses, and the two cases where the
+//! inverses are required to disagree.
+
+use hiroz_schema::type_name::{
+    KINDS, dds_from_canonical, dds_from_namespace, ros_from_dds, ros_from_dds_strict,
+    service_from_response, split_canonical,
+};
+
+/// The exact string `rmw_zenoh_cpp` was measured to declare on the wire for
+/// `demo_nodes_cpp talker`, recovered from a raw zenoh subscriber on `**`.
+const MEASURED_WIRE_NAME: &str = "std_msgs::msg::dds_::String_";
+
+#[test]
+fn the_canonical_and_namespace_forms_agree() {
+    assert_eq!(
+        dds_from_canonical("std_msgs/msg/String").unwrap(),
+        dds_from_namespace("std_msgs::msg", "String")
+    );
+    assert_eq!(
+        dds_from_canonical("std_msgs/msg/String").unwrap(),
+        MEASURED_WIRE_NAME
+    );
+}
+
+#[test]
+fn every_kind_round_trips() {
+    for kind in KINDS {
+        let canonical = format!("my_pkg/{kind}/Thing");
+        let dds = dds_from_canonical(&canonical).unwrap();
+        assert_eq!(dds, format!("my_pkg::{kind}::dds_::Thing_"));
+        assert_eq!(ros_from_dds_strict(&dds), canonical);
+        assert_eq!(ros_from_dds(&dds), canonical);
+    }
+}
+
+#[test]
+fn an_empty_namespace_is_legal() {
+    assert_eq!(dds_from_namespace("", "Bare"), "dds_::Bare_");
+    assert_eq!(ros_from_dds_strict("dds_::Bare_"), "Bare");
+}
+
+#[test]
+fn action_sub_types_go_through_the_same_rule() {
+    assert_eq!(
+        dds_from_namespace("my_pkg::action", "Fib_SendGoal"),
+        "my_pkg::action::dds_::Fib_SendGoal_"
+    );
+    assert_eq!(
+        ros_from_dds_strict("my_pkg::action::dds_::Fib_SendGoal_"),
+        "my_pkg/action/Fib_SendGoal"
+    );
+}
+
+#[test]
+fn a_service_name_comes_from_its_response_name() {
+    let response = dds_from_namespace("example_interfaces::srv", "AddTwoInts_Response");
+    assert_eq!(
+        response,
+        "example_interfaces::srv::dds_::AddTwoInts_Response_"
+    );
+    assert_eq!(
+        service_from_response(&response).unwrap(),
+        dds_from_canonical("example_interfaces/srv/AddTwoInts").unwrap()
+    );
+}
+
+#[test]
+fn a_name_that_is_not_a_response_has_no_service_name() {
+    assert_eq!(service_from_response("std_msgs::msg::dds_::String_"), None);
+    assert_eq!(service_from_response("AddTwoInts_Response"), None);
+}
+
+#[test]
+fn split_canonical_rejects_what_is_not_canonical() {
+    assert_eq!(
+        split_canonical("std_msgs/msg/String"),
+        Some(("std_msgs", "msg", "String"))
+    );
+    assert_eq!(split_canonical("std_msgs/String"), None);
+    assert_eq!(split_canonical("a/b/c/d"), None);
+    assert_eq!(split_canonical("std_msgs/nope/String"), None);
+    assert_eq!(dds_from_canonical("std_msgs/nope/String"), None);
+}
+
+/// The one case where the two inverses are required to disagree.
+#[test]
+fn the_strict_inverse_leaves_a_name_without_dds_alone_and_the_lenient_one_does_not() {
+    let no_dds_segment = "rcl_interfaces::msg::ParameterEvent_";
+    assert_eq!(ros_from_dds_strict(no_dds_segment), no_dds_segment);
+    assert_eq!(
+        ros_from_dds(no_dds_segment),
+        "rcl_interfaces/msg/ParameterEvent"
+    );
+}
+
+#[test]
+fn both_inverses_leave_a_name_that_is_already_canonical_alone() {
+    for input in ["std_msgs/msg/String", "", "plain", "pkg/srv/Name_Request"] {
+        assert_eq!(
+            ros_from_dds_strict(input),
+            input,
+            "strict changed {input:?}"
+        );
+        assert_eq!(ros_from_dds(input), input, "lenient changed {input:?}");
+    }
+}
+
+/// The second case where the two are required to differ. The lenient one
+/// trims a trailing underscore from any name, which is what the schema
+/// lookup it serves has always done; the strict one may not, because
+/// `rmw_zenoh_cpp` does not.
+#[test]
+fn only_the_lenient_inverse_trims_a_trailing_underscore_from_a_foreign_name() {
+    assert_eq!(
+        ros_from_dds_strict("some::other::Type_"),
+        "some::other::Type_"
+    );
+    assert_eq!(ros_from_dds("some::other::Type_"), "some::other::Type");
+}

--- a/crates/hiroz-union/src/plugin/wasm/host/ros.rs
+++ b/crates/hiroz-union/src/plugin/wasm/host/ros.rs
@@ -622,12 +622,13 @@ impl hu::plugin::ros::HostServiceClient for PluginState {
 /// (`pkg::srv::dds_::Name_Request_` / `pkg::srv::dds_::Name_`). All normalize to
 /// bare `pkg/srv/Name` first, so suffixes are never double-appended.
 fn service_request_response_type_names(service_type: &str) -> (String, String) {
-    let normalized = service_type.replace("dds_::", "").replace("::", "/");
-    let normalized = normalized.strip_suffix('_').unwrap_or(&normalized);
-    let normalized = normalized
+    // Use the lenient rule, because service_type may already be canonical. The
+    // shared rule returns such a name unchanged.
+    let canonical = hiroz::dynamic::ros_type_name_from_dds(service_type);
+    let normalized = canonical
         .strip_suffix("_Request")
-        .or_else(|| normalized.strip_suffix("_Response"))
-        .unwrap_or(normalized);
+        .or_else(|| canonical.strip_suffix("_Response"))
+        .unwrap_or(&canonical);
     match normalized.split_once("/srv/") {
         Some((pkg, name)) => (
             format!("{pkg}/msg/{name}Request"),

--- a/crates/hiroz/src/dynamic/type_description_service.rs
+++ b/crates/hiroz/src/dynamic/type_description_service.rs
@@ -422,14 +422,7 @@ impl RegisteredSchema {
 /// `pkg::msg::Foo` → `pkg/msg/Foo`
 /// `pkg/msg/Foo` → `pkg/msg/Foo` (unchanged)
 fn normalize_type_name_for_lookup(name: &str) -> String {
-    name.replace("::msg::dds_::", "/msg/")
-        .replace("::srv::dds_::", "/srv/")
-        .replace("::action::dds_::", "/action/")
-        .replace("::msg::", "/msg/")
-        .replace("::srv::", "/srv/")
-        .replace("::action::", "/action/")
-        .trim_end_matches('_')
-        .to_string()
+    hiroz_schema::type_name::ros_from_dds(name)
 }
 
 /// a background task that would block on queue.recv().

--- a/crates/hiroz/src/dynamic/type_info.rs
+++ b/crates/hiroz/src/dynamic/type_info.rs
@@ -4,12 +4,10 @@ use crate::dynamic::{MessageSchema, MessageSchemaTypeDescription};
 use crate::entity::{TypeHash, TypeInfo};
 
 pub(crate) fn dds_type_name_from_schema(schema: &MessageSchema) -> String {
-    schema
-        .type_name
-        .replace("/msg/", "::msg::dds_::")
-        .replace("/srv/", "::srv::dds_::")
-        .replace("/action/", "::action::dds_::")
-        + "_"
+    // A schema whose type_name is not canonical has nothing to mangle. Pass it
+    // through. The old string replacement half-mangled it instead.
+    hiroz_schema::type_name::dds_from_canonical(&schema.type_name)
+        .unwrap_or_else(|| schema.type_name.clone())
 }
 
 /// Convert a DDS-mangled type name as it appears in liveliness tokens and the
@@ -18,16 +16,15 @@ pub(crate) fn dds_type_name_from_schema(schema: &MessageSchema) -> String {
 /// out-of-crate consumers (e.g. `hu`'s WASM host) resolve graph-reported types
 /// against `load_schema` and must use this exact normalisation rather than
 /// re-deriving one -- see issue #172.
+///
+/// This is the **lenient** inverse. It tolerates a name that has no `dds_::`
+/// segment, because such a name must still resolve against the schema registry.
+/// An RMW graph boundary needs the strict inverse instead, which is
+/// [`hiroz_schema::ros_from_dds_strict`]. That one matches `rmw_zenoh_cpp`.
+/// Both live in `hiroz_schema::type_name`, the one place that states the
+/// rule.
 pub fn ros_type_name_from_dds(dds_name: &str) -> String {
-    dds_name
-        .replace("::msg::dds_::", "/msg/")
-        .replace("::srv::dds_::", "/srv/")
-        .replace("::action::dds_::", "/action/")
-        .replace("::msg::", "/msg/")
-        .replace("::srv::", "/srv/")
-        .replace("::action::", "/action/")
-        .trim_end_matches('_')
-        .to_string()
+    hiroz_schema::type_name::ros_from_dds(dds_name)
 }
 
 pub(crate) fn schema_hash(schema: &MessageSchema) -> TypeHash {

--- a/crates/hiroz/src/node.rs
+++ b/crates/hiroz/src/node.rs
@@ -3,6 +3,11 @@ use std::{sync::Arc, time::Duration};
 use tracing::{debug, info, warn};
 use zenoh::{Result, Session, Wait, liveliness::LivelinessToken};
 
+// Only the FFI action paths below mangle a type name. This import therefore
+// carries the same gate as the code that uses it.
+#[cfg(feature = "ffi")]
+use hiroz_schema::type_name::dds_from_namespace;
+
 #[cfg(feature = "ffi")]
 use crate::ffi::publisher::RawPublisher;
 use crate::{
@@ -834,17 +839,19 @@ impl ZNode {
         // Compute DDS-style type names required by rmw_zenoh_cpp's graph discovery.
         // action_type is e.g. "example_interfaces/action/Fibonacci" → package="example_interfaces", name="Fibonacci"
         let (pkg, aname) = split_action_type(action_type);
-        let send_goal_type = format!("{}::action::dds_::{}_SendGoal_", pkg, aname);
-        let get_result_type = format!("{}::action::dds_::{}_GetResult_", pkg, aname);
-        let cancel_goal_type = "action_msgs::srv::dds_::CancelGoal_";
-        let feedback_type_dds = format!("{}::action::dds_::{}_FeedbackMessage_", pkg, aname);
+        let action_ns = format!("{pkg}::action");
+        let send_goal_type = dds_from_namespace(&action_ns, &format!("{aname}_SendGoal"));
+        let get_result_type = dds_from_namespace(&action_ns, &format!("{aname}_GetResult"));
+        let cancel_goal_type = dds_from_namespace("action_msgs::srv", "CancelGoal");
+        let feedback_type_dds =
+            dds_from_namespace(&action_ns, &format!("{aname}_FeedbackMessage"));
 
         let send_goal_client =
             self.create_raw_service_client(&send_goal_service, &send_goal_type, goal_hash)?;
         let get_result_client =
             self.create_raw_service_client(&get_result_service, &get_result_type, result_hash)?;
         let cancel_goal_client =
-            self.create_raw_service_client(&cancel_goal_service, cancel_goal_type, "")?;
+            self.create_raw_service_client(&cancel_goal_service, &cancel_goal_type, "")?;
 
         // Feedback subscriber (no-op callback for now; Go handles via polling or separate mechanism)
         let feedback_sub =
@@ -882,22 +889,24 @@ impl ZNode {
         // Compute DDS-style type names required by rmw_zenoh_cpp's graph discovery.
         // action_type is e.g. "example_interfaces/action/Fibonacci" → package="example_interfaces", name="Fibonacci"
         let (pkg, aname) = split_action_type(action_type);
-        let send_goal_type = format!("{}::action::dds_::{}_SendGoal_", pkg, aname);
-        let get_result_type = format!("{}::action::dds_::{}_GetResult_", pkg, aname);
-        let cancel_goal_type = "action_msgs::srv::dds_::CancelGoal_";
-        let feedback_type_dds = format!("{}::action::dds_::{}_FeedbackMessage_", pkg, aname);
-        let status_type_dds = "action_msgs::msg::dds_::GoalStatusArray_";
+        let action_ns = format!("{pkg}::action");
+        let send_goal_type = dds_from_namespace(&action_ns, &format!("{aname}_SendGoal"));
+        let get_result_type = dds_from_namespace(&action_ns, &format!("{aname}_GetResult"));
+        let cancel_goal_type = dds_from_namespace("action_msgs::srv", "CancelGoal");
+        let feedback_type_dds =
+            dds_from_namespace(&action_ns, &format!("{aname}_FeedbackMessage"));
+        let status_type_dds = dds_from_namespace("action_msgs::msg", "GoalStatusArray");
 
         let send_goal_server =
             self.create_raw_service_server(&send_goal_service, &send_goal_type, goal_hash)?;
         let get_result_server =
             self.create_raw_service_server(&get_result_service, &get_result_type, result_hash)?;
         let cancel_goal_server =
-            self.create_raw_service_server(&cancel_goal_service, cancel_goal_type, "")?;
+            self.create_raw_service_server(&cancel_goal_service, &cancel_goal_type, "")?;
 
         let feedback_pub =
             self.create_raw_publisher(&feedback_topic, &feedback_type_dds, feedback_hash)?;
-        let status_pub = self.create_raw_publisher(&status_topic, status_type_dds, "")?;
+        let status_pub = self.create_raw_publisher(&status_topic, &status_type_dds, "")?;
 
         Ok(crate::ffi::action::RawActionServer {
             send_goal_server,

--- a/crates/rmw-zenoh-rs/Cargo.toml
+++ b/crates/rmw-zenoh-rs/Cargo.toml
@@ -34,6 +34,7 @@ hiroz-cdr = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 hiroz = { workspace = true, features = ["rmw"] }
 hiroz-protocol = { workspace = true }
+hiroz-schema = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 
 [lib]

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -19,6 +19,9 @@ use hiroz::{
     Builder,
     event::{RmEventHandle, ZenohEventType},
 };
+// The graph holds wire-form type names. Every RMW query below is a boundary.
+// Each one must report the ROS form instead, as rmw_zenoh_cpp does.
+use hiroz_protocol::format::rmw_zenoh::ros_type_name;
 
 use crate::{
     pubsub::{PublisherImpl, SubscriptionImpl},
@@ -1501,7 +1504,7 @@ pub extern "C" fn rmw_get_topic_names_and_types(
 
             // Populate type names
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(topic_names_and_types);
@@ -1623,7 +1626,7 @@ pub extern "C" fn rmw_get_service_names_and_types(
 
             // Populate type names
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(service_names_and_types);
@@ -1975,7 +1978,7 @@ pub extern "C" fn rmw_get_publishers_info_by_topic(
 
             // Set topic type
             if let Some(ref type_info) = endpoint.type_info {
-                let type_cstr = match std::ffi::CString::new(type_info.name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(&type_info.name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_topic_endpoint_info_array_fini(publishers_info, allocator as *mut _);
@@ -2175,7 +2178,7 @@ pub extern "C" fn rmw_get_subscriber_names_and_types_by_node(
 
             // Populate type names
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(topic_names_and_types);
@@ -3047,7 +3050,7 @@ pub extern "C" fn rmw_get_client_names_and_types_by_node(
             }
 
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(service_names_and_types);
@@ -3216,7 +3219,7 @@ pub extern "C" fn rmw_get_publisher_names_and_types_by_node(
             }
 
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(topic_names_and_types);
@@ -3391,7 +3394,7 @@ pub extern "C" fn rmw_get_service_names_and_types_by_node(
             }
 
             for (type_index, type_name) in type_names.iter().enumerate() {
-                let type_cstr = match std::ffi::CString::new(type_name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(type_name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_names_and_types_fini(service_names_and_types);
@@ -3522,7 +3525,7 @@ pub extern "C" fn rmw_get_subscriptions_info_by_topic(
 
             // Set topic type
             if let Some(ref type_info) = endpoint.type_info {
-                let type_cstr = match std::ffi::CString::new(type_info.name.as_str()) {
+                let type_cstr = match std::ffi::CString::new(ros_type_name(&type_info.name)) {
                     Ok(s) => s,
                     Err(_) => {
                         rmw_topic_endpoint_info_array_fini(subscriptions_info, allocator as *mut _);

--- a/crates/rmw-zenoh-rs/src/type_support.rs
+++ b/crates/rmw-zenoh-rs/src/type_support.rs
@@ -80,6 +80,8 @@ mod ffi {
 
 use ffi::*;
 use hiroz::entity::{TypeHash, TypeInfo};
+use hiroz_protocol::format::rmw_zenoh::dds_type_name;
+use hiroz_schema::type_name::service_from_response;
 
 use crate::ros::rosidl_type_hash_t;
 
@@ -162,42 +164,21 @@ impl MessageTypeSupport {
         res
     }
 
+    /// The type name as it appears in an rmw_zenoh key expression, e.g.
+    /// `std_msgs::msg::dds_::String_`.
+    ///
+    /// This calls the one shared helper. It therefore cannot drift away from
+    /// the name that `hiroz-codegen` bakes into generated messages.
     pub fn get_type_prefix(&self) -> String {
         let (name, namespace) = unsafe {
             let ts = self.as_ref();
             (get_message_name(ts), get_message_namespace(ts))
         };
-
-        let ns = if namespace.is_empty() {
-            ""
-        } else {
-            &(namespace + "::")
-        };
-        format!("{ns}dds_::{name}_")
-    }
-
-    /// Get the ROS type name in the format "namespace/msg/Name" (without DDS mangling)
-    pub fn get_ros_type_name(&self) -> String {
-        let (name, namespace) = unsafe {
-            let ts = self.as_ref();
-            (get_message_name(ts), get_message_namespace(ts))
-        };
-
-        // Remove trailing underscore from name (DDS mangling)
-        let clean_name = name.strip_suffix('_').unwrap_or(&name);
-
-        // Format as ROS type name: replace :: with / in namespace
-        if namespace.is_empty() {
-            clean_name.to_string()
-        } else {
-            // Replace C++ namespace separators (::) with ROS separators (/)
-            let ros_namespace = namespace.replace("::", "/");
-            format!("{}/{}", ros_namespace, clean_name)
-        }
+        dds_type_name(&namespace, &name)
     }
 
     pub fn get_type_info(&self) -> TypeInfo {
-        TypeInfo::new(&self.get_ros_type_name(), self.get_type_hash())
+        TypeInfo::new(&self.get_type_prefix(), self.get_type_hash())
     }
 }
 
@@ -258,10 +239,9 @@ impl ServiceTypeSupport {
     }
 
     pub fn get_type_info(&self) -> TypeInfo {
-        let name_with_suffix = self.response.get_ros_type_name();
-        let name = name_with_suffix
-            .strip_suffix("_Response")
-            .expect("Invalid Response type - must end with _Response");
-        TypeInfo::new(name, self.get_type_hash())
+        let response = self.response.get_type_prefix();
+        let name = service_from_response(&response)
+            .expect("Invalid Response type - must end with _Response_");
+        TypeInfo::new(&name, self.get_type_hash())
     }
 }

--- a/scripts/test-ros.nu
+++ b/scripts/test-ros.nu
@@ -124,10 +124,72 @@ def run-ros-interop [] {
 # Test Suite Configuration
 # ============================================================================
 
+# Assert that the RMW graph APIs report the ROS type name, not the DDS wire form.
+#
+# The graph stores the wire form, because liveliness tokens carry it. Every RMW
+# query must demangle on the way out, as rmw_zenoh_cpp does in graph_cache.cpp.
+# A regression makes `ros2 topic list -t` print `std_msgs::msg::dds_::String_`
+# instead of `std_msgs/msg/String`.
+#
+# Not in the default pipeline: it needs rmw_zenoh_rs built and on the RMW search
+# path, which only the rmw_zenoh_rs workflow sets up. Run it by name there.
+def graph-type-names [] {
+    log-step "Graph queries report the ROS type name"
+
+    let topic = "/chatter"
+    let expected = "std_msgs/msg/String"
+
+    # Unset, the RMW emits 18446744073709551615 as the domain. That builds a
+    # different key expression, which looks exactly like the defect under test.
+    $env.ROS_DOMAIN_ID = ($env.ROS_DOMAIN_ID? | default "0")
+    $env.RMW_IMPLEMENTATION = ($env.RMW_IMPLEMENTATION? | default "rmw_zenoh_rs")
+    print $"  RMW_IMPLEMENTATION=($env.RMW_IMPLEMENTATION) ROS_DOMAIN_ID=($env.ROS_DOMAIN_ID)"
+
+    # rmw_zenoh peers need a router. Nothing else in this process starts one,
+    # and without it the talker cannot open a session and exits at once.
+    ^pkill -9 zenohd | ignore
+    sleep 500ms
+    let router = job spawn { ^ros2 run rmw_zenoh_cpp rmw_zenohd }
+    sleep 2sec
+
+    let talker = job spawn { ^ros2 run demo_nodes_cpp talker }
+
+    mut listing = ""
+    for _ in 1..30 {
+        $listing = (^ros2 topic list -t | complete | get stdout)
+        if ($listing | str contains $topic) { break }
+        sleep 1sec
+    }
+
+    # A job that already exited is gone, and `job kill` on it throws. Guard both,
+    # or a dead talker reports "Job N not found" and hides the real diagnosis.
+    try { job kill $talker }
+    try { job kill $router }
+    ^pkill -9 zenohd | ignore
+
+    print "  --- ros2 topic list -t ---"
+    print $listing
+
+    # Prove the probe saw something before trusting any assertion about it. An
+    # empty listing would satisfy "no wire form" while proving nothing.
+    if not ($listing | str contains $topic) {
+        error make { msg: $"($topic) never appeared, so this run proves nothing. Check that the router started and that ($env.RMW_IMPLEMENTATION) is on the RMW search path." }
+    }
+    if not ($listing | str contains $expected) {
+        error make { msg: $"the graph did not report ($expected)" }
+    }
+    if ($listing | str contains "dds_::") {
+        error make { msg: "the graph leaked the DDS wire form" }
+    }
+
+    log-success $"the graph reports ($expected) and no wire form"
+}
+
 def get-test-map [] {
     {
         clippy-rmw: { clippy-rmw }
         run-ros-interop: { run-ros-interop }
+        graph-type-names: { graph-type-names }
     }
 }
 
@@ -162,8 +224,12 @@ def main [
     ...tests: string             # Specific test functions to run (optional)
 ] {
     if $list {
+        let pipeline = get-test-pipeline
         print "Available test functions:"
-        get-test-pipeline | each { |name| print $"  - ($name)" }
+        get-test-map | columns | each { |name|
+            let mark = if $name in $pipeline { "" } else { "  (not in the default run)" }
+            print $"  - ($name)($mark)"
+        }
         return
     }
 
@@ -175,9 +241,11 @@ def main [
 
     let tests_to_run = if ($tests | is-empty) { $pipeline } else { $tests }
 
-    # Validate test names
+    # Validate against the map, not the pipeline. The map is every runnable
+    # test; the pipeline is only the default order. A test registered in the
+    # map but left out of the pipeline must still be runnable by name.
     for test_name in $tests_to_run {
-        if $test_name not-in $pipeline {
+        if $test_name not-in ($test_map | columns) {
             error make {
                 msg: $"Test function '($test_name)' not found"
                 label: {


### PR DESCRIPTION
## Summary

`rmw_zenoh_rs` derives the topic key expression from a slash-separated type name. The hiroz library, and upstream `rmw_zenoh_cpp`, use the DDS-mangled form. They differ in one segment, so a hiroz library node and a ROS 2 node running `rmw_zenoh_rs` match no topic and exchange nothing. Neither side reports an error.

| side | key expression |
|---|---|
| hiroz library | `0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c74…` |
| `rmw_zenoh_rs` | `0/chatter/std_msgs/msg/String/RIHS01_df668c74…` |

The domain matches. The type hash matches byte for byte. Only the type name differs.

`get_type_info()` feeds both the key expression and the liveliness token. It read `get_ros_type_name()`, while `get_type_prefix()` sat beside it in the same file and produced the mangled form.

## Which side is wrong was measured

A `demo_nodes_cpp` talker ran under `RMW_IMPLEMENTATION=rmw_zenoh_cpp`. A raw zenoh subscriber on `**` recorded the key it declared:

```
0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18
```

The library matches the wire. `rmw_zenoh_rs` is the outlier, so `rmw_zenoh_rs` is what changes here. Patching the library instead would have broken the `test.yml` leg that passes today.

The key expression is also the only difference. Raw CDR bytes published on the `rmw_zenoh_rs` key, produced by no ROS code and carrying no attachment, reached a `demo_nodes_cpp` listener. The two stacks already agree on domain, type hash, encapsulation and envelope.

## Why CI is green

A missing edge, not a weak test. `test.yml` pairs the library with `rmw_zenoh_cpp`. `rmw-zenoh-rs.yml` pairs `rmw_zenoh_rs` with ROS packages. No leg pairs the library with `rmw_zenoh_rs`.

## What this changes

| | today | with this change |
|---|---|---|
| `get_type_info()` | reads `get_ros_type_name()` | reads `get_type_prefix()` |
| `get_ros_type_name()` | exists, called twice | deleted |
| `type_name_dyn()` vs `type_info_dyn()` | disagree | agree |
| the key on the wire | `…/std_msgs/msg/String/…` | `…/std_msgs::msg::dds_::String_/…` |
| a hiroz node and an `rmw_zenoh_rs` node | exchange nothing, silently | exchange messages |
| `ros2 topic list -t`, local topic | right, from the wrong name | right, demangled at the boundary |
| `ros2 topic list -t`, remote topic | **`std_msgs::msg::dds_::String_`** | `std_msgs/msg/String` |

**The graph leak on the last row is older than this change.** hiroz builds the graph from liveliness tokens. Those tokens already carry the mangled form for every hiroz peer and every `rmw_zenoh_cpp` peer. So `rmw_get_topic_names_and_types` already reports the mangled name for a remote publisher on `main` today. On its own this change would extend that to local topics as well.

`ros_from_dds_strict` closes both halves. It is a port of `_demangle_if_ros_type` in `rmw_zenoh_cpp`'s `graph_cache.cpp`, applied at all eight sites that copy a graph type name into an RMW result.

## One rule, ten call sites

Review asked why several derivations existed at all. The rule now lives once, in `hiroz_schema::type_name`, and ten production sites call it: `hiroz-protocol`, both `hiroz-codegen` generators, `hiroz-derive`, two `hiroz::dynamic` paths, two action blocks in `hiroz::node`, `hiroz-py`, and `hiroz-union`. Four of those were independent inverses. `dds_::` now appears in no production `format!` or `replace` outside that module.

`hiroz-schema` is the home because it already owns the canonical form, and because it is a leaf crate. Nothing pulls `zenoh` into a build script or a proc macro.

**Two inverses remain, on purpose.** `ros_from_dds_strict` matches the reference byte for byte, which an RMW boundary requires. `ros_from_dds` falls back for a name that has no `dds_::` segment, because such a name must still resolve against the schema registry. Both differences were accidental before. A test now pins each.

## What fails without this

| stage | result |
|---|---|
| RED | `library_and_rmw_derive_the_same_topic_key` fails on the assertion: `left: "std_msgs/msg/String"`, `right: "std_msgs::msg::dds_::String_"` |
| GREEN | the crate's tests pass, `cargo fmt --check` clean |
| end to end | library talker to `demo_nodes_cpp` listener under `rmw_zenoh_rs`: **35 received**. Reverse: **29 received**. The sniffed key matches the `rmw_zenoh_cpp` measurement |
| re-falsified | reverting the mangling turns the tests red and drops the listener to **0 received of 22 published** |

## Tests

All 15 tests this change adds live in dedicated files, not an inline `mod tests`. Both crates already carried a `tests/` directory.

| file | tests | covers |
|---|---|---|
| `crates/hiroz-schema/tests/type_name.rs` | 10 | the forward rule, both inverses, every kind, the empty namespace, action sub-types, and the two cases where the inverses must disagree |
| `crates/hiroz-protocol/tests/type_name_agreement.rs` | 5 | the topic key, the service key, the liveliness token, the three action interfaces, and the service-name rule |

The pre-existing inline module in `rmw_zenoh.rs` keeps its own 33 tests. Moving those too would add churn to a defect fix; that belongs in its own pull request.

## Breaking changes

| tag | what changes | who is affected | before → after | action |
|---|---|---|---|---|
| BC1 | `MessageTypeSupport::get_ros_type_name()` is removed | any external caller | `std_msgs/msg/String` → call `get_type_prefix()` | call `get_type_prefix()` |
| BC2 | the key `rmw_zenoh_rs` publishes on changes | a peer matching the old slash-form key | `…/std_msgs/msg/String/…` → `…/std_msgs::msg::dds_::String_/…` | none — the new key is the one `rmw_zenoh_cpp` and the library already use |
| BC3 | RMW graph queries demangle | a caller expecting the mangled form from a remote peer | `std_msgs::msg::dds_::String_` → `std_msgs/msg/String` | none — this is the form ROS tooling expects |

No caller of `get_ros_type_name()` exists in this repository beyond the two this change rewrites.

## Coverage

| what | where it runs |
|---|---|
| the derivation, both inverses, service and action names, the liveliness token | 15 unit tests in two dedicated files |
| the library against `rmw_zenoh_cpp`, four distros | `Interop Tests`, which runs `hiroz-tests` with `ros-interop` |
| the Humble `no-type-hash` configuration | the same job's humble leg, `--no-default-features --features ros-interop,humble` |
| `rmw_zenoh_rs` against ROS packages | `rmw_zenoh_rs with ROS 2 Jazzy` |
| **the RMW graph reporting the ROS type name** | a new `test-ros.nu` check, run by that same workflow |

The check lives in `scripts/test-ros.nu`, which already registers this project's ROS-dependent tests. It starts a talker under `RMW_IMPLEMENTATION=rmw_zenoh_rs`, then asserts `ros2 topic list -t` prints `std_msgs/msg/String` and no `dds_::`. It also asserts `/chatter` appeared at all, so a probe that saw nothing fails instead of passing.

It stays out of the default pipeline, because it needs `rmw_zenoh_rs` built and on the RMW search path. Only the `rmw_zenoh_rs` workflow sets that up, and it runs the check by name.

That required one fix to the script. `main` validated a requested test against the *pipeline*, so any test registered in the map but left out of the default order was unrunnable. It now validates against the map, and `--list` marks which tests the default run skips.

The detector was proven to detect, against a stub `ros2`:

| the listing says | result |
|---|---|
| `std_msgs/msg/String` | passes |
| `std_msgs::msg::dds_::String_` | **fails**: "the graph did not report std_msgs/msg/String" |
| nothing, talker dead | **fails**: "/chatter never appeared, so this run proves nothing" |

The check starts its own `rmw_zenohd`, because rmw_zenoh peers need a router and nothing else in that step starts one. It guards both `job kill` calls: a talker that already exited makes an unguarded kill throw "Job N not found", which hides the real diagnosis behind a Nushell error.

## Not verified

The end-to-end runs used `std_msgs/String` only. Tests cover the service path, the action interfaces and the liveliness token at the formatter. No live ROS service exercises them.

This touches no file that #325 touches, so the two can land in either order.
