### PR TITLE
chore(config): retire the two zenoh 1.9 removed routing keys

### DIFF
--- a/crates/hiroz/src/config.rs
+++ b/crates/hiroz/src/config.rs
@@ -6,7 +6,7 @@
 //!
 //! # Architecture
 //! - Common overrides: 10 settings shared between router and session
-//! - Router-specific: 5 settings unique to router mode
+//! - Router-specific: 4 settings unique to router mode
 //! - Session-specific: 6 settings unique to peer mode
 //!
 //! # Example
@@ -195,7 +195,7 @@ fn common_overrides() -> &'static [ConfigOverride] {
     &COMMON
 }
 
-/// Router-specific overrides (5 settings)
+/// Router-specific overrides (4 settings)
 fn router_specific_overrides() -> &'static [ConfigOverride] {
     static ROUTER_SPECIFIC: LazyLock<Vec<ConfigOverride>> = LazyLock::new(|| {
         vec![
@@ -213,11 +213,6 @@ fn router_specific_overrides() -> &'static [ConfigOverride] {
                 key: "connect/endpoints",
                 value: serde_json::json!([]),
                 reason: "Router does not connect to other endpoints (empty list)",
-            },
-            ConfigOverride {
-                key: "routing/router/peers_failover_brokering",
-                value: serde_json::json!(false),
-                reason: "Changed from true to false - unnecessary when peers connect directly, reduces overhead",
             },
             ConfigOverride {
                 key: "transport/link/tx/queue/congestion_control/block/wait_before_close",

--- a/crates/hiroz/tests/no_deprecated_zenoh_keys.rs
+++ b/crates/hiroz/tests/no_deprecated_zenoh_keys.rs
@@ -1,0 +1,149 @@
+//! The shipped configs must set no key the zenoh version in use has removed.
+//!
+//! # What this pins
+//!
+//! `routing.router.peers_failover_brokering` governed whether a router forwards
+//! between two peers attached to it that cannot reach each other. zenoh 1.9
+//! removed it. The runtime says so on every start of anything that sets it:
+//!
+//! ```text
+//! WARN zenoh_config: `routing.router.peers_failover_brokering` is deprecated
+//! and has no effect; please remove it from your configuration
+//! ```
+//!
+//! hiroz set it in two places, and they disagreed with each other. The library
+//! set `false`; `rmw-zenoh-rs`'s vendored session config set `true`. Neither
+//! did anything.
+//!
+//! # Why a test rather than a one-off deletion
+//!
+//! A deprecated key is invisible. It compiles, it validates, it produces a
+//! warning nobody reads, and it stays right until someone measures. Deleting
+//! the two occurrences fixes today; this test is what notices the next one.
+//!
+//! # What this test cannot do
+//!
+//! It knows only the keys named in `REMOVED_KEYS`, so it catches a
+//! reintroduction rather than a newly deprecated key. A zenoh upgrade that
+//! retires something else passes this test in silence. Adding the new name here
+//! is part of taking that upgrade.
+
+use hiroz::config::{router_overrides, session_overrides};
+
+/// Keys the zenoh version this crate builds against no longer honours.
+///
+/// Each entry is the key as `ConfigOverride` spells it, the version that
+/// removed it, and what replaced it.
+/// A key the zenoh version this crate builds against no longer honours.
+///
+/// `override_token` is what a `ConfigOverride` key path contains.
+/// `file_tokens` are what a JSON5 config file contains, because a file spells
+/// the same key as nested blocks rather than a path. The two surfaces need
+/// different needles for the same key.
+struct RemovedKey {
+    override_token: &'static str,
+    file_tokens: &'static [&'static str],
+    removed_in: &'static str,
+    replacement: &'static str,
+}
+
+const REMOVED_KEYS: &[RemovedKey] = &[
+    RemovedKey {
+        override_token: "peers_failover_brokering",
+        file_tokens: &["peers_failover_brokering"],
+        removed_in: "zenoh 1.9",
+        replacement: "a router per host, or peer subregions",
+    },
+    // zenoh 1.9 removed `routing.peer` entirely; every peer is peer-to-peer
+    // now. Its deserializer warns about `mode` and `linkstate` alike, so the
+    // override side matches the parent and the file side matches the values,
+    // which are what a JSON5 block actually contains.
+    RemovedKey {
+        override_token: "routing/peer",
+        file_tokens: &["peer_to_peer", "linkstate"],
+        removed_in: "zenoh 1.9",
+        replacement: "nothing; peer-to-peer is the only behaviour",
+    },
+];
+
+/// Neither shipped override list may name a key zenoh has removed.
+///
+/// This inspects what hiroz *sets*, not the `zenoh::Config` it produces. The
+/// rendered config carries every key with its default, so it cannot tell an
+/// override from a field that merely exists — an earlier version of this test
+/// checked that and failed on a clean tree.
+#[test]
+fn the_shipped_overrides_name_no_removed_key() {
+    for (label, overrides) in [
+        ("session", session_overrides()),
+        ("router", router_overrides()),
+    ] {
+        // An empty list would satisfy every assertion below while proving
+        // nothing.
+        assert!(
+            !overrides.is_empty(),
+            "the {label} override list is empty; this test would pass vacuously"
+        );
+
+        for removed in REMOVED_KEYS {
+            let found = overrides
+                .iter()
+                .find(|o| o.key.contains(removed.override_token));
+            assert!(
+                found.is_none(),
+                "the shipped {label} overrides set `{}`, which {} removed. \
+                 It has no effect, and the runtime warns about it at every start. \
+                 Use {} instead.",
+                found.map(|o| o.key).unwrap_or(removed.override_token),
+                removed.removed_in,
+                removed.replacement
+            );
+        }
+    }
+}
+/// The vendored `rmw-zenoh-rs` config files may not set one either.
+///
+/// Those are JSON5 shipped as files rather than built through `ConfigOverride`,
+/// so the check above cannot see them. This is the path that carried
+/// `peers_failover_brokering: true` — in a *session* config, where a key about
+/// router forwarding has no meaning even on a runtime that honoured it.
+#[test]
+fn the_vendored_config_files_set_no_removed_key() {
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../rmw-zenoh-rs/config");
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read {dir}: {e}"))
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json5"))
+        .collect::<Vec<_>>();
+
+    // An empty sweep would pass while checking nothing.
+    assert!(
+        !entries.is_empty(),
+        "no .json5 config files found under {dir}; this test would pass vacuously"
+    );
+
+    for entry in entries {
+        let path = entry.path();
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+        for removed in REMOVED_KEYS {
+            // Skip commented lines: the upstream files carry long `///` blocks
+            // that legitimately name the key while documenting it.
+            let live = text
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .find(|l| removed.file_tokens.iter().any(|t| l.contains(t)));
+
+            assert!(
+                live.is_none(),
+                "{} sets `{}`, which {} removed. Use {} instead. Offending line: {}",
+                path.display(),
+                removed.override_token,
+                removed.removed_in,
+                removed.replacement,
+                live.unwrap_or("").trim()
+            );
+        }
+    }
+}

--- a/crates/rmw-zenoh-rs/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/crates/rmw-zenoh-rs/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -48,22 +48,6 @@
   /// The default timeout to apply to queries in milliseconds.
   queries_default_timeout: 10000,
 
-  /// The routing strategy to use and it's configuration.
-  routing: {
-    /// The routing strategy to use in routers and it's configuration.
-    router: {
-      /// When set to true a router will forward data between two peers
-      /// directly connected to it if it detects that those peers are not
-      /// connected to each other.
-      peers_failover_brokering: true,
-    },
-    /// The routing strategy to use in peers and it's configuration.
-    peer: {
-      /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
-      mode: "peer_to_peer",
-    },
-  },
-
   /// Configure internal transport parameters
   transport: {
     unicast: {


### PR DESCRIPTION
## Summary

zenoh 1.9 removed two config keys that hiroz still set. `zenoh-config` carries a deprecation wrapper for each, and warns on both.

| key | where hiroz set it | value |
|---|---|---|
| `routing.router.peers_failover_brokering` | `crates/hiroz/src/config.rs`, router overrides | `false` |
| `routing.router.peers_failover_brokering` | `crates/rmw-zenoh-rs/config/…SESSION_CONFIG.json5` | `true` |
| `routing.peer.mode` | the same JSON5 file | `"peer_to_peer"` |

The two settings of the first key disagreed with each other. None of the three does anything. The runtime says so on every start of anything that sets it:

```
WARN zenoh_config: `routing.router.peers_failover_brokering` is deprecated and
has no effect; please remove it from your configuration
```

This change removes all three, and adds a test that pins their absence. With `routing.peer` gone the JSON5 file's `routing` block held nothing live, so that goes too.

The second one is also in the wrong file. It is a **session** config, and the key governs what a *router* does when forwarding between two peers attached to it. A session is not a router, so it would have had no effect there even on a runtime that honoured it.

## What the key used to do, measured

The flag was real. It is still live on `rmw_zenoh_cpp` jazzy 0.2.9, where the same measurement runs both ways with one word changed in the router config:

| `peers_failover_brokering` | published | cross-host heard |
|---|---|---|
| `false` (its shipped value) | 75 | **0** |
| `true` | 75 | **75** |

The listener's own log gives the mechanism:

```
false: WARN ... Unable to connect to any locator of scouted peer c76ee898...: [tcp/[::1]:34357]
true:  [INFO] [lb1]: I heard: [Hello World: 1]
```

That the `false` cell *scouted* the talker proves both nodes shared a router. Gossip reached across; only the data path did not.

**So zenoh 1.9 removed a capability, not a dead option.** Know that before deleting the key. It also deserves a line in whatever documents the upgrade.

## Why removing it costs nothing here

| | |
|---|---|
| the capability only applies to two peers sharing **one** router | a router does not relay between peers attached to it without this flag |
| hiroz defaults to a router **per host** | `connect/endpoints` is `tcp/localhost:7447`, so every node reaches a router on its own machine |
| in that topology the key has no role | traffic crosses router to router, which this flag never governed |
| both projects already shipped it off | hiroz `false`, `rmw_zenoh_cpp` `false` |

Measured across topologies, hiroz delivers cross-host either way:

| router layout | cross-host heard / published | cross-host peer links |
|---|---|---|
| router per host (the default) | **149 / 150** | 0 |
| one shared router | 0 / 150 | 0 |

The shared-router row is a separate problem, and this change does not address it. This records it rather than fixing it, because a deployment reaches that row only by overriding the shipped connect endpoint.

## What fails without this

Nothing fails. The keys are inert; that is the point.

| | today | with this change |
|---|---|---|
| `the_shipped_overrides_name_no_removed_key` | **fails**: the router overrides name `peers_failover_brokering` | passes |
| `the_vendored_config_files_set_no_removed_key` | **fails**: the session JSON5 sets both keys | passes |
| router startup | warns about a deprecated key | silent |

Both assertions run in every direction: green as committed, then one red probe per key per surface — four in all, each returning rc=101. Each arm fires only on its own surface, so they are two independent checks rather than one written twice. Both also assert their input is non-empty, so neither can pass vacuously.

The two surfaces need different needles for the same key. An override spells it as a path, `routing/peer/mode`; a JSON5 file spells it as nested blocks with the value on the leaf. An earlier version of this test used one token for both and would have missed the file side in silence.

An earlier revision of that test asserted against `format!("{config:?}")`. That renders zenoh's whole config tree, defaults included. It therefore could not tell an override from a field that merely exists, and it failed on a clean tree. It now inspects `router_overrides()` and `session_overrides()` — what hiroz sets.

## Test results

| check | result |
|---|---|
| `cargo test -p hiroz` on this branch | 55 passed, 7 failed |
| `cargo test -p hiroz` on `main` | 55 passed, 7 failed |
| failures unique to this branch | **none** |
| `cargo clippy -p hiroz --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |

The 7 are pre-existing doctest *compile* failures in `action/client.rs` and `action/server.rs` (`ZActionClient`, `ZActionClientBuilder`, `GoalHandle`, `ZActionServerBuilder`). Confirmed against `main` rather than assumed.

## Breaking changes

None. Both keys are inert on zenoh 1.9, so no behaviour changes at any setting.

## Not verified

- `hiroz` on zenoh 1.8. Every "the flag was live" number above comes from `rmw_zenoh_cpp` jazzy 0.2.9, which is a different stack. A true before-and-after needs hiroz pinned to `zenoh = "1.8"`.
- The zenoh version behind that C++ build. `libzenohc.so` carries no symbols, and three probe strategies recovered no version string.
- Whether any deployment relied on this flag. Both projects shipped it off, but a user config could have set it.
