### PR TITLE
fix(ci): run doctests and lint the ffi feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,16 @@ jobs:
           nu scripts/test-pure-rust.nu run-tests
         shell: bash
 
+      # Separate from "Run tests" because `cargo nextest` cannot run doctests.
+      # Without this step nothing in the pipeline ever compiles a `///` example.
+      - name: Run doctests
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /tmp/nix-dev-env.sh
+          fi
+          nu scripts/test-pure-rust.nu run-doctests
+        shell: bash
+
   no-ros-shm:
     name: SHM Tests (ubuntu-latest)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,16 @@ jobs:
           nu scripts/test-pure-rust.nu clippy-tests
         shell: bash
 
+      # `ffi` is not a default feature, so the workspace clippy above never
+      # compiles crates/hiroz/src/ffi/. Naming the feature is what reaches it.
+      - name: Clippy (hiroz, ffi feature)
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /tmp/nix-dev-env.sh
+          fi
+          nu scripts/test-pure-rust.nu clippy-ffi
+        shell: bash
+
   hu-aarch64-cross:
     name: hu cross-compiles for aarch64 Linux
     runs-on: ubuntu-latest

--- a/crates/hiroz/src/action/client.rs
+++ b/crates/hiroz/src/action/client.rs
@@ -31,6 +31,7 @@ pub mod goal_state {
 /// # Examples
 ///
 /// ```no_run
+/// # use hiroz::Builder;
 /// # use hiroz::action::*;
 /// # use hiroz::qos::QosProfile;
 /// # use hiroz_msgs::action_tutorials_interfaces::action::Fibonacci;
@@ -289,6 +290,7 @@ impl<'a, A: ZAction> Builder for ZActionClientBuilder<'a, A> {
 /// # Simple Goal Send/Receive
 ///
 /// ```no_run
+/// # use hiroz::Builder;
 /// # use hiroz::action::*;
 /// # use hiroz_msgs::action_tutorials_interfaces::{FibonacciGoal, action::Fibonacci};
 /// # #[tokio::main]
@@ -306,6 +308,7 @@ impl<'a, A: ZAction> Builder for ZActionClientBuilder<'a, A> {
 ///
 /// ```no_run
 /// # use hiroz::action::*;
+/// # use hiroz::action::client::{GoalHandle, goal_state};
 /// # use hiroz_msgs::action_tutorials_interfaces::action::Fibonacci;
 /// # #[tokio::main]
 /// # async fn main() -> zenoh::Result<()> {
@@ -324,6 +327,7 @@ impl<'a, A: ZAction> Builder for ZActionClientBuilder<'a, A> {
 ///
 /// ```no_run
 /// # use hiroz::action::*;
+/// # use hiroz::action::client::{GoalHandle, ZActionClient, goal_state};
 /// # use hiroz_msgs::action_tutorials_interfaces::action::Fibonacci;
 /// # #[tokio::main]
 /// # async fn main() -> zenoh::Result<()> {
@@ -396,6 +400,7 @@ impl<A: ZAction> ZActionClient<A> {
     ///
     /// ```no_run
     /// # use hiroz::action::*;
+    /// # use hiroz::action::client::ZActionClient;
     /// # use hiroz_msgs::action_tutorials_interfaces::{FibonacciGoal, action::Fibonacci};
     /// # #[tokio::main]
     /// # async fn main() -> zenoh::Result<()> {
@@ -540,6 +545,7 @@ struct GoalChannels<A: ZAction> {
 ///
 /// ```no_run
 /// # use hiroz::action::*;
+/// # use hiroz::action::client::{GoalHandle, goal_state};
 /// # use hiroz_msgs::action_tutorials_interfaces::action::Fibonacci;
 /// # #[tokio::main]
 /// # async fn main() -> zenoh::Result<()> {

--- a/crates/hiroz/src/action/server.rs
+++ b/crates/hiroz/src/action/server.rs
@@ -124,6 +124,7 @@ impl Drop for ShutdownGuard {
 /// # Examples
 ///
 /// ```no_run
+/// # use hiroz::Builder;
 /// # use hiroz::action::*;
 /// # use std::time::Duration;
 /// # use hiroz_msgs::action_tutorials_interfaces::action::Fibonacci;

--- a/crates/hiroz/src/config.rs
+++ b/crates/hiroz/src/config.rs
@@ -350,7 +350,12 @@ pub fn session_config() -> zenoh::Result<zenoh::Config> {
 /// Useful for generating reference configuration files.
 ///
 /// # Example
-/// ```rust
+// `no_run`, not `rust`: this example writes a file, and doctests run with the
+// crate directory as their working directory. Executed, it drops
+// `crates/hiroz/router_config.json5` into the source tree on every run --
+// including CI's, now that doctests run there. Compiling it is what this
+// example is worth; running it is only a side effect.
+/// ```no_run
 /// # use hiroz::config::{generate_json5, router_overrides};
 /// let json5 = generate_json5(&router_overrides(), "Router Config");
 /// std::fs::write("router_config.json5", json5)?;

--- a/crates/hiroz/src/ffi/action.rs
+++ b/crates/hiroz/src/ffi/action.rs
@@ -76,6 +76,11 @@ pub struct CGoalHandle {
 }
 
 /// Create an action client
+///
+/// # Safety
+/// `node` must be a pointer returned by `hiroz_node_create`, or null.
+/// Every string argument must be a valid null-terminated C string, or null.
+/// The returned pointer must be freed with `hiroz_action_client_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_client_create(
     node: *mut CNode,
@@ -156,6 +161,12 @@ pub unsafe extern "C" fn hiroz_action_client_create(
 
 /// Send a goal to an action server.
 /// On success, writes the goal_id (16 bytes) and creates a goal handle.
+///
+/// # Safety
+/// `client_handle` must be a pointer returned by `hiroz_action_client_create`, or null.
+/// `goal_data` must be valid for reads of `goal_len` bytes.
+/// `goal_id` must be valid for writes of 16 bytes, and `handle` for writes of one pointer.
+/// On success, `*handle` must be freed with `hiroz_goal_handle_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_client_send_goal(
     client_handle: *mut CActionClient,
@@ -223,6 +234,12 @@ pub unsafe extern "C" fn hiroz_action_client_send_goal(
 }
 
 /// Get result for a goal
+///
+/// # Safety
+/// `goal_handle` must be a pointer written by `hiroz_action_client_send_goal`, or null.
+/// `result_data` and `result_len` must each be valid for writes.
+/// On success, the buffer written to `*result_data` must be freed with
+/// `hiroz_free_bytes(*result_data, *result_len)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_client_get_result(
     goal_handle: *mut CGoalHandle,
@@ -273,6 +290,10 @@ pub unsafe extern "C" fn hiroz_action_client_get_result(
 }
 
 /// Cancel a goal
+///
+/// # Safety
+/// `goal_handle` must be a pointer written by `hiroz_action_client_send_goal`, or null.
+/// Its originating client must not have been destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_client_cancel_goal(goal_handle: *mut CGoalHandle) -> i32 {
     if goal_handle.is_null() {
@@ -298,6 +319,11 @@ pub unsafe extern "C" fn hiroz_action_client_cancel_goal(goal_handle: *mut CGoal
 }
 
 /// Destroy an action client
+///
+/// # Safety
+/// `client` must be a pointer returned by `hiroz_action_client_create`, or null.
+/// It must not be used again afterwards, and no goal handle derived from it may
+/// outlive this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_client_destroy(client: *mut CActionClient) -> i32 {
     if client.is_null() {
@@ -318,6 +344,14 @@ unsafe extern "C" {
 /// Create an action server.
 /// Spawns a background thread that polls for goals, calls the goal callback,
 /// and if accepted, calls the execute callback.
+///
+/// # Safety
+/// `node` must be a pointer returned by `hiroz_node_create`, or null.
+/// Every string argument must be a valid null-terminated C string, or null.
+/// `goal_callback` and `execute_callback` must remain callable for the lifetime of
+/// the server; a background thread invokes them from a thread the caller does not own.
+/// `user_data` is passed back to them unchanged and is not dereferenced here.
+/// The returned pointer must be freed with `hiroz_action_server_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_create(
     node: *mut CNode,
@@ -623,6 +657,11 @@ pub unsafe extern "C" fn hiroz_action_server_create(
 }
 
 /// Publish feedback for a goal
+///
+/// # Safety
+/// `server_handle` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// `goal_id` must be valid for reads of 16 bytes, and `feedback_data` for reads of
+/// `feedback_len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_publish_feedback(
     server_handle: *mut CActionServer,
@@ -663,6 +702,11 @@ pub unsafe extern "C" fn hiroz_action_server_publish_feedback(
 }
 
 /// Mark a goal as succeeded
+///
+/// # Safety
+/// `server_handle` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// `goal_id` must be valid for reads of 16 bytes, and `result_data` for reads of
+/// `result_len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_succeed(
     server_handle: *mut CActionServer,
@@ -674,6 +718,11 @@ pub unsafe extern "C" fn hiroz_action_server_succeed(
 }
 
 /// Mark a goal as aborted
+///
+/// # Safety
+/// `server_handle` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// `goal_id` must be valid for reads of 16 bytes, and `result_data` for reads of
+/// `result_len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_abort(
     server_handle: *mut CActionServer,
@@ -685,6 +734,11 @@ pub unsafe extern "C" fn hiroz_action_server_abort(
 }
 
 /// Mark a goal as canceled
+///
+/// # Safety
+/// `server_handle` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// `goal_id` must be valid for reads of 16 bytes, and `result_data` for reads of
+/// `result_len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_canceled(
     server_handle: *mut CActionServer,
@@ -730,6 +784,10 @@ unsafe fn store_result(
 
 /// Check whether a cancel has been requested for the given goal.
 /// Returns 1 if cancel was requested, 0 otherwise.
+///
+/// # Safety
+/// `server_handle` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// `goal_id` must be valid for reads of 16 bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_is_cancel_requested(
     server_handle: *mut CActionServer,
@@ -751,6 +809,10 @@ pub unsafe extern "C" fn hiroz_action_server_is_cancel_requested(
 }
 
 /// Destroy an action server
+///
+/// # Safety
+/// `server` must be a pointer returned by `hiroz_action_server_create`, or null.
+/// It must not be used again afterwards.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_action_server_destroy(server: *mut CActionServer) -> i32 {
     if server.is_null() {
@@ -768,6 +830,10 @@ pub unsafe extern "C" fn hiroz_action_server_destroy(server: *mut CActionServer)
 }
 
 /// Destroy a goal handle
+///
+/// # Safety
+/// `handle` must be a pointer written by `hiroz_action_client_send_goal`, or null.
+/// It must not be used again afterwards.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_goal_handle_destroy(handle: *mut CGoalHandle) -> i32 {
     if handle.is_null() {

--- a/crates/hiroz/src/ffi/serialize.rs
+++ b/crates/hiroz/src/ffi/serialize.rs
@@ -7,6 +7,13 @@ use std::ffi::c_char;
 /// Serialize a message to CDR format
 /// Input: type_name (C string), raw message bytes from Go
 /// Output: CDR serialized bytes via out_ptr/out_len
+///
+/// # Safety
+/// `type_name` must be a valid null-terminated C string, or null.
+/// `msg_data` must be valid for reads of `msg_len` bytes.
+/// `out_ptr` and `out_len` must each be valid for writes.
+/// On success, the buffer written to `*out_ptr` must be freed with
+/// `hiroz_free_bytes(*out_ptr, *out_len)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_serialize(
     type_name: *const c_char,
@@ -41,6 +48,13 @@ pub unsafe extern "C" fn hiroz_serialize(
 }
 
 /// Deserialize CDR bytes to raw format for Go
+///
+/// # Safety
+/// `type_name` must be a valid null-terminated C string, or null.
+/// `cdr_data` must be valid for reads of `cdr_len` bytes.
+/// `out_ptr` and `out_len` must each be valid for writes.
+/// On success, the buffer written to `*out_ptr` must be freed with
+/// `hiroz_free_bytes(*out_ptr, *out_len)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_deserialize(
     type_name: *const c_char,
@@ -74,11 +88,21 @@ pub unsafe extern "C" fn hiroz_deserialize(
 }
 
 /// Free bytes allocated by serialize/deserialize
+///
+/// # Safety
+/// `ptr` must be a buffer this crate returned through an out-parameter, or null,
+/// and `len` must be exactly the length it reported alongside it. Passing any other
+/// pointer, or a mismatched length, is undefined behaviour. Each buffer must be
+/// freed at most once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_free_bytes(ptr: *mut u8, len: usize) {
     if !ptr.is_null() && len > 0 {
         unsafe {
-            let _ = Box::from_raw(std::slice::from_raw_parts_mut(ptr, len));
+            // `slice_from_raw_parts_mut` builds the fat pointer directly.
+            // Taking `&mut [u8]` first, as `slice::from_raw_parts_mut` does,
+            // asserts a unique reference the caller has not promised, and
+            // clippy's `implicit_slice_from_raw_parts` flags the reborrow.
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len));
         }
     }
 }

--- a/crates/hiroz/src/ffi/service.rs
+++ b/crates/hiroz/src/ffi/service.rs
@@ -181,6 +181,11 @@ pub struct CServiceServer {
 }
 
 /// Create a service client
+///
+/// # Safety
+/// `node` must be a pointer returned by `hiroz_node_create`, or null.
+/// Every string argument must be a valid null-terminated C string, or null.
+/// The returned pointer must be freed with `hiroz_service_client_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_client_create(
     node: *mut CNode,
@@ -225,6 +230,13 @@ pub unsafe extern "C" fn hiroz_service_client_create(
 
 /// Call a service (synchronous with timeout).
 /// Response bytes are allocated via Rust and must be freed with hiroz_free_bytes.
+///
+/// # Safety
+/// `client_handle` must be a pointer returned by `hiroz_service_client_create`, or null.
+/// `request_data` must be valid for reads of `request_len` bytes.
+/// `response_data` and `response_len` must each be valid for writes.
+/// On success, the buffer written to `*response_data` must be freed with
+/// `hiroz_free_bytes(*response_data, *response_len)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_client_call(
     client_handle: *mut CServiceClient,
@@ -267,6 +279,10 @@ pub unsafe extern "C" fn hiroz_service_client_call(
 }
 
 /// Destroy a service client
+///
+/// # Safety
+/// `client` must be a pointer returned by `hiroz_service_client_create`, or null.
+/// It must not be used again afterwards.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_client_destroy(client: *mut CServiceClient) -> i32 {
     if client.is_null() {
@@ -282,6 +298,9 @@ pub unsafe extern "C" fn hiroz_service_client_destroy(client: *mut CServiceClien
 /// Wait until at least one matching service server is visible in the graph,
 /// or `timeout_ms` elapses. Returns `Success` (0) if ready, `ServiceTimeout`
 /// (-10) on timeout, `NullPointer` (-1) if `client` is null.
+///
+/// # Safety
+/// `client_handle` must be a pointer returned by `hiroz_service_client_create`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_client_wait_for_service(
     client_handle: *mut CServiceClient,
@@ -308,6 +327,14 @@ unsafe extern "C" {
 /// Create a service server.
 /// The server spawns a background thread that polls for incoming requests,
 /// invokes the callback for each one, and sends the response.
+///
+/// # Safety
+/// `node` must be a pointer returned by `hiroz_node_create`, or null.
+/// Every string argument must be a valid null-terminated C string, or null.
+/// `callback` must remain callable for the lifetime of the server; a background
+/// thread invokes it from a thread the caller does not own. `user_data` is passed
+/// back to it unchanged and is not dereferenced here.
+/// The returned pointer must be freed with `hiroz_service_server_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_server_create(
     node: *mut CNode,
@@ -426,6 +453,10 @@ pub unsafe extern "C" fn hiroz_service_server_create(
 }
 
 /// Destroy a service server
+///
+/// # Safety
+/// `server` must be a pointer returned by `hiroz_service_server_create`, or null.
+/// It must not be used again afterwards.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hiroz_service_server_destroy(server: *mut CServiceServer) -> i32 {
     if server.is_null() {

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -52,6 +52,16 @@ def run-doctests [] {
     run-cmd "cargo test -p hiroz --doc"
 }
 
+def clippy-ffi [] {
+    log-step "Clippy (hiroz, ffi feature)"
+    # `clippy-workspace` runs `--all-targets` with *default* features, so the
+    # `ffi` module is never linted -- it is behind a non-default feature. That
+    # left 22 `missing_safety_doc` errors and one raw-pointer cast standing on
+    # `main`, invisible to a fully green pipeline. `--all-targets` alone does
+    # not reach a feature; the feature has to be named.
+    run-cmd "cargo clippy -p hiroz --features ffi --all-targets -- -D warnings"
+}
+
 def check-bundled-msgs [] {
     log-step "Check hiroz-msgs with bundled messages"
     run-cmd "cargo check -p hiroz-msgs"
@@ -196,6 +206,7 @@ def get-test-map [] {
         check-distro-features: { check-distro-features }
         clippy-hiroz-py: { clippy-hiroz-py }
         clippy-tests: { clippy-tests }
+        clippy-ffi: { clippy-ffi }
         test-shm: { test-shm }
     }
 }
@@ -213,6 +224,7 @@ def get-test-pipeline [] {
         "check-distro-features"
         "clippy-hiroz-py"
         "clippy-tests"
+        "clippy-ffi"
         "test-shm"
     ]
 }

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -36,6 +36,22 @@ def run-tests [] {
     run-cmd "cargo nextest run --no-fail-fast -p hiroz-tests --features ros-msgs,jazzy"
 }
 
+def run-doctests [] {
+    log-step "Run doctests"
+    # `cargo nextest` does not execute doctests, and it is the only test runner
+    # `run-tests` calls -- so until this step existed, no job in this repository
+    # ever compiled a `///` example. Seven of them in `crates/hiroz/src/action/`
+    # had not compiled for as long as anyone measured: their hidden preambles
+    # omitted `use hiroz::Builder` or named `ZActionClient` / `GoalHandle` /
+    # `goal_state`, which `hiroz::action` does not re-export. `cargo doc`
+    # (check-rustdoc-links) does not catch this -- it resolves intra-doc links
+    # and never builds the examples.
+    #
+    # Scoped to `hiroz`: it is the crate whose examples users read. Widen it
+    # when another crate's doc examples are worth the compile time.
+    run-cmd "cargo test -p hiroz --doc"
+}
+
 def check-bundled-msgs [] {
     log-step "Check hiroz-msgs with bundled messages"
     run-cmd "cargo check -p hiroz-msgs"
@@ -171,6 +187,7 @@ def get-test-map [] {
     {
         clippy-workspace: { clippy-workspace }
         run-tests: { run-tests }
+        run-doctests: { run-doctests }
         check-bundled-msgs: { check-bundled-msgs }
         check-hu: { check-hu }
         check-examples: { check-examples }
@@ -187,6 +204,7 @@ def get-test-pipeline [] {
     [
         "clippy-workspace"
         "run-tests"
+        "run-doctests"
         "check-bundled-msgs"
         "check-hu"
         "check-examples"


### PR DESCRIPTION
## Summary

Two checks have never run in this repository. Each one, run for the first time, fails on `main`.

| check | result on `main` (`1fe6b3d619a7a92e4455e864318a8039583f4865`) | why CI missed it |
|---|---|---|
| `cargo test -p hiroz --doc` | `rc=101` — **7 failed**, 55 passed, 32 ignored | `run-tests` drives `cargo nextest`, which does not execute doctests. No workflow passes `--doc` |
| `cargo clippy -p hiroz --features ffi --all-targets -- -D warnings` | `rc=101` — **23 errors** | `clippy-workspace` runs `--all-targets` with *default* features. `ffi` is not one |

Both failures are old, both are invisible, and a fully green pipeline says nothing about either. This PR fixes the code and adds the step that would have caught it, one commit per pair.

## The two gaps are the same shape

`--all-targets` reaches every *target* of the features it was given. It does not reach a *feature* nobody named. `cargo nextest` runs every test *binary*. It does not run doctests, which are not binaries.

In both cases the flag reads as exhaustive and is not. That is why neither gap was noticed: the commands look like they already cover the ground.

## Commit 1 — doctests

Seven doc examples in `crates/hiroz/src/action/` do not compile, in two groups:

| examples | fault |
|---|---|
| `ZActionClientBuilder`, `ZActionClient` (simple send/receive), `ZActionServerBuilder` | call `.build()` with no `use hiroz::Builder` in scope |
| `ZActionClient` (feedback), `ZActionClient` (cancellation), `send_goal`, `GoalHandle` | name `ZActionClient`, `GoalHandle` or `goal_state`, none of which `hiroz::action` re-exports — it exports `ClientGoalHandle` and the server type-state markers only |

The second group is the more interesting one. `hiroz::action`'s own docs say `ClientGoalHandle` exists "to avoid the name collision with `server::GoalHandle`", so the glob deliberately does not carry the client types. Four examples assumed it did, and nothing ever told them otherwise.

Every fix goes in the hidden `#` preamble, so **no rendered example changes**.

`generate_json5`'s example also becomes `no_run`. Doctests run with the crate directory as their working directory, so executing it writes `crates/hiroz/router_config.json5` into the source tree. Harmless while nothing ran doctests; a file left behind on every CI run and every developer's `cargo test` once something did. Found by reading the worker's `git status` after the first green run, not by reasoning about it.

`check-rustdoc-links` does not overlap with the new step: `cargo doc` resolves intra-doc links and never builds an example.

## Commit 2 — the `ffi` feature

23 errors: 22 `missing_safety_doc` and one `implicit_slice_from_raw_parts`.

| file | `missing_safety_doc` |
|---|---|
| `ffi/action.rs` | 13 |
| `ffi/service.rs` | 6 |
| `ffi/serialize.rs` | 3 |

`ffi/context.rs` and `ffi/graph.rs` already carry `# Safety` sections, so the convention existed — nothing enforced it, and the three files added later never picked it up.

Each contract names which constructor produced the pointer, which spans must be valid for reads or writes, and which function frees what. `hiroz_free_bytes` gets the strictest, because it is the one a caller can most easily get wrong:

> `ptr` must be a buffer this crate returned through an out-parameter, or null, and `len` must be exactly the length it reported alongside it. Passing any other pointer, or a mismatched length, is undefined behaviour. Each buffer must be freed at most once.

`hiroz_free_bytes` also stops going through `slice::from_raw_parts_mut` on its way to `Box::from_raw`. That reborrow asserts a unique `&mut [u8]` the caller has not promised; `ptr::slice_from_raw_parts_mut` builds the fat pointer without it.

## Before and after

| | today | with this change |
|---|---|---|
| `cargo test -p hiroz --doc` | **`rc=101`, 7 failed** | `rc=0`, 62 passed |
| `cargo clippy -p hiroz --features ffi ... -D warnings` | **`rc=101`, 23 errors** | `rc=0` |
| `cargo clippy --all-targets -- -D warnings` | `rc=0` | `rc=0` — unchanged |
| a `///` example that stops compiling | ships | fails `Run doctests` |
| an undocumented `unsafe extern "C" fn` | ships | fails `Clippy (hiroz, ffi feature)` |
| `cargo test --doc` in a clean tree | writes `crates/hiroz/router_config.json5` | leaves the tree clean |
| CI checks on `no-ros-test` / `no-ros-checks` | — | one new step each |

## What fails without this

Both directions measured on the same worker, in `.#pureRust-ci`, at the head of this branch:

| stage | `run-doctests` | `clippy-ffi` |
|---|---|---|
| with the fix | `rc=0` | `rc=0` |
| fix reverted to `1fe6b3d619a7a92e4455e864318a8039583f4865` | **`rc=1`** — `FAILED. 55 passed; 7 failed; 32 ignored` | **`rc=1`** — 22 `missing a '# Safety' section` |

The revert is per-half: `crates/hiroz/src/action/` alone for the first column, `crates/hiroz/src/ffi/` alone for the second. Each gate was shown to go red for its own defect and no other. `cargo clippy --all-targets -- -D warnings` stayed `rc=0` throughout, so neither commit regresses the existing lint surface.

## Cost

Two extra steps on jobs that already build the crate, so both reuse a warm `target/`. The doctest run itself took 14 s on the worker; the `ffi` clippy run is a single-crate lint.

## Out of scope

`Cargo.lock` is stale on `main`: `protobuf_demo` is still pinned at `0.1.0` after the `0.2.0` release, so any cargo invocation rewrites one line and dirties the tree. Observed on `main` before this branch existed, on three separate jobs. Not touched here — it belongs in its own commit, and now has one: **#330**.

## Breaking changes

None. No public signature changes, no rendered doc example changes, no behaviour changes. The `# Safety` sections state the contract that C callers were already required to honour; they do not narrow it.

