### PR TITLE
fix(release): realign the stale Cargo.lock entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "protobuf_demo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "hiroz",

--- a/scripts/test-release-version-semantics.sh
+++ b/scripts/test-release-version-semantics.sh
@@ -307,19 +307,99 @@ echo "== every workspace crate inherits one version =="
 # The nested plugins workspace under crates/hiroz-union/plugins is `exclude`d
 # and its versions are cosmetic -- release assets are named for the workspace
 # version -- so it is deliberately not covered here.
+#
+# Read the `members` list rather than globbing `crates/*/Cargo.toml`. That glob
+# is one level deep, so it never saw `crates/hiroz/examples/protobuf_demo` --
+# a real workspace member, and the one member whose Cargo.lock entry the 0.2.0
+# release left at 0.1.0. A check that cannot see a member cannot vouch for it.
+members() { # print each member path listed in the root Cargo.toml
+    awk '
+        /^members[[:space:]]*=[[:space:]]*\[/ { inside = 1; next }
+        inside && /^\]/                       { exit }
+        inside {
+            if (match($0, /"[^"]+"/))
+                print substr($0, RSTART + 1, RLENGTH - 2)
+        }
+    ' "$ROOT/Cargo.toml"
+}
+
+MEMBERS=$(members)
+MEMBER_COUNT=$(printf '%s\n' "$MEMBERS" | grep -c .)
+# Guard the parser itself: an awk change that stops matching would leave every
+# loop below iterating over nothing and reporting a clean pass.
+if [ "$MEMBER_COUNT" -ge 10 ]; then
+    ok "parsed $MEMBER_COUNT workspace members from Cargo.toml"
+else
+    bad "parsed only $MEMBER_COUNT workspace members -- the members parser is broken"
+fi
+
 stray=""
-for f in "$ROOT"/crates/*/Cargo.toml; do
+for m in $MEMBERS; do
+    f="$ROOT/$m/Cargo.toml"
+    [ -f "$f" ] || { bad "member $m has no Cargo.toml"; continue; }
     v=$(grep -m1 '^version' "$f" 2>/dev/null || true)
     case "$v" in
         *workspace*) ;;
         "")          ;;
-        *)           stray="$stray $(basename "$(dirname "$f")")" ;;
+        *)           stray="$stray $m" ;;
     esac
 done
 if [ -z "$stray" ]; then
     ok "no crate carries a literal version"
 else
     bad "these crates carry a literal version instead of version.workspace:$stray"
+fi
+
+echo
+echo "== Cargo.lock agrees with the workspace version =="
+# The 0.2.0 release bumped 11 of the 12 members in Cargo.lock and left
+# protobuf_demo at 0.1.0, because the lock was edited by pattern rather than
+# regenerated. Nothing noticed: no job passes --locked, so cargo silently
+# rewrote that line on every build and every run left the tree dirty.
+#
+# This compares the lock against the manifests directly, so it needs no cargo,
+# no network and no build -- the same properties as the rest of this suite.
+WS_VERSION=$(awk '
+    /^\[workspace\.package\]/ { inside = 1; next }
+    inside && /^\[/           { exit }
+    inside && /^version[[:space:]]*=/ {
+        if (match($0, /"[^"]+"/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+    }
+' "$ROOT/Cargo.toml")
+check "the workspace declares a version" 1 "$([ -n "$WS_VERSION" ] && echo 1 || echo 0)"
+
+# The lock keys on the package name, which need not equal the directory name.
+lock_version() { # package name
+    awk -v want="$1" '
+        $0 == "name = \"" want "\"" { found = 1; next }
+        found && /^version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+            exit
+        }
+    ' "$ROOT/Cargo.lock"
+}
+
+lock_stray=""
+lock_checked=0
+for m in $MEMBERS; do
+    f="$ROOT/$m/Cargo.toml"
+    [ -f "$f" ] || continue
+    name=$(awk '/^name[[:space:]]*=/ { if (match($0, /"[^"]+"/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit } }' "$f")
+    [ -n "$name" ] || { bad "member $m declares no package name"; continue; }
+    got=$(lock_version "$name")
+    lock_checked=$((lock_checked + 1))
+    if [ -z "$got" ]; then
+        lock_stray="$lock_stray $name(absent)"
+    elif [ "$got" != "$WS_VERSION" ]; then
+        lock_stray="$lock_stray $name($got)"
+    fi
+done
+check "every member was looked up in Cargo.lock" "$MEMBER_COUNT" "$lock_checked"
+if [ -z "$lock_stray" ]; then
+    ok "all $lock_checked members are at $WS_VERSION in Cargo.lock"
+else
+    bad "Cargo.lock disagrees with the workspace version $WS_VERSION for:$lock_stray"
+    printf '         run `cargo metadata --offline >/dev/null` and commit Cargo.lock\n'
 fi
 
 echo


### PR DESCRIPTION
## Summary

The 0.2.0 release bumped **11 of the workspace's 12 members** in `Cargo.lock` and left `protobuf_demo` at `0.1.0`:

| member | `Cargo.lock` |
|---|---|
| `hiroz`, `hiroz-cdr`, `hiroz-codegen`, `hiroz-derive`, `hiroz-protocol`, `hiroz-py`, `rmw-zenoh-rs`, `hiroz-schema`, `hiroz-msgs`, `hiroz-tests`, `hiroz-union` | `0.2.0` |
| **`protobuf_demo`** | **`0.1.0`** |

Its manifest says `version.workspace = true`, so cargo rewrites that one line on **every invocation** and every build leaves the tree dirty. Observed on three separate jobs, all of which only read `main`.

This realigns the line and adds the checks that would have caught it.

## Why nothing noticed

Two independent reasons, and the second is the more interesting one.

**No job passes `--locked`**, so the rewrite is silent — cargo fixes the lock, the build succeeds, and the modification is only visible to someone who runs `git status` afterwards.

**The check that polices versions could not see the crate.** `scripts/test-release-version-semantics.sh` already asserts that no crate carries a literal version instead of `version.workspace`. It found them by globbing:

```sh
for f in "$ROOT"/crates/*/Cargo.toml; do
```

That glob is one level deep. `protobuf_demo` lives at `crates/hiroz/examples/protobuf_demo`, so it was never examined — measured directly: the old glob matches the nested member **`no`**.

That blindness is the same shape as the release's own miss. Both walked a `crates/*` pattern; both skipped the one member that is not directly under `crates/`. The crate happens to inherit correctly today, so the gate reported a pass on a crate it had not looked at.

## What changed

All three changes land in `test-release-version-semantics.sh`, which already runs on every pull request and needs **no cargo, no network and no build** — the same properties as the rest of that suite.

| change | why |
|---|---|
| the inheritance check reads the `members` list from `Cargo.toml` instead of globbing | a check that cannot see a member cannot vouch for it |
| a new check compares every member's `Cargo.lock` version against `[workspace.package] version` | this defect, directly |
| the members parser guards itself (`>= 10` members parsed) | an awk change that stopped matching would leave both loops iterating over nothing and reporting a clean pass |

The third row is not decoration. Both new loops are driven by the same parser, so a silent parse failure would turn two checks green simultaneously — zero iterations and zero failures look identical.

## Before and after

| | today | with this change |
|---|---|---|
| `protobuf_demo` in `Cargo.lock` | `0.1.0` | `0.2.0` |
| `cargo build` on a clean checkout | rewrites `Cargo.lock`, leaves the tree dirty | leaves the tree clean |
| a member's lock entry drifting from the workspace version | ships, silently | fails `Release workflow version semantics` |
| a **nested** member carrying a literal version | invisible to the gate | fails the gate |
| a broken members parser | would report a clean pass | fails the gate |
| checks in the suite | 59 | 62 |

## What fails without this

Run locally — the suite needs no toolchain. Each red case is reverted before the next.

| direction | result |
|---|---|
| unmodified | **pass** — `62 passed, 0 failed`; 12 members parsed, all at `0.2.0` |
| `Cargo.lock` line put back to `0.1.0` | **fail** — ``Cargo.lock disagrees with the workspace version 0.2.0 for: protobuf_demo(0.1.0)`` |
| `version.workspace = true` → a literal, in the **nested** member | **fail** — ``these crates carry a literal version instead of version.workspace: crates/hiroz/examples/protobuf_demo`` |
| the members parser broken | **fail** — ``parsed only 0 workspace members -- the members parser is broken`` |

The third row is the one that matters most, because it is the case the previous gate silently passed. Confirmed separately that the old glob does not match that path, so this is a real gap being closed rather than a restatement of existing coverage.

## On the lock edit being hand-made

It is one line, and it is byte-identical to what cargo produces. The resulting blob is `5148407d2` — the same git object a cargo invocation wrote on a clean checkout of `main` before this branch existed. That is why the edit is safe to make without running cargo here.

## Not addressed

Adding `--locked` to CI's cargo invocations would catch this class at the build rather than in a bespoke check. It is a larger change — it makes every dependency update an explicit lock commit, and it would need each job audited for jobs that legitimately resolve — so it belongs in its own change, not folded into a one-line fix.

## Breaking changes

None. No manifest, no dependency resolution and no version number changes — `Cargo.lock` is brought into agreement with what the manifests already declared.
