### PR TITLE
fix(hiroz-msgs): allow publishing to crates.io

### DIFF
--- a/crates/hiroz-msgs/Cargo.toml
+++ b/crates/hiroz-msgs/Cargo.toml
@@ -2,10 +2,15 @@
 name = "hiroz-msgs"
 version.workspace = true
 edition.workspace = true
-publish = false
+description = "ROS 2 message, service, and action types for hiroz, generated at build time"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["ros2", "zenoh", "robotics", "messages", "codegen"]
+categories = ["network-programming", "science::robotics"]
 
 [dependencies]
-hiroz = { path = "../hiroz", default-features = false, features = [
+hiroz = { version = "0.2", path = "../hiroz", default-features = false, features = [
   "rmw-zenoh",
 ] }
 serde = { workspace = true }
@@ -17,7 +22,7 @@ zenoh-buffers = { workspace = true }
 
 prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
-hiroz-derive = { path = "../hiroz-derive", optional = true }
+hiroz-derive = { version = "0.2", path = "../hiroz-derive", optional = true }
 hiroz-cdr = { workspace = true }
 byteorder = { workspace = true }
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/hiroz-msgs/Cargo.toml
+++ b/crates/hiroz-msgs/Cargo.toml
@@ -22,7 +22,7 @@ zenoh-buffers = { workspace = true }
 
 prost = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
-hiroz-derive = { version = "0.2", path = "../hiroz-derive", optional = true }
+hiroz-derive = { workspace = true, optional = true }
 hiroz-cdr = { workspace = true }
 byteorder = { workspace = true }
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -33,7 +33,12 @@ fn main() -> Result<()> {
     // a sibling path in this crate's own directory), so ask hiroz-codegen for its
     // own bundled-assets location. This resolves correctly whether hiroz-codegen
     // is consumed via path (workspace) or from crates.io.
-    let codegen_assets = hiroz_codegen::bundled_assets_dir(is_humble);
+    //
+    // Always the jazzy corpus, never `is_humble`: hiroz-codegen ships only the
+    // jazzy assets populated (assets/humble exists but is empty), and the
+    // package list below already excludes post-Humble-only interfaces, so the
+    // jazzy corpus is the correct bundled fallback for a Humble build too.
+    let codegen_assets = hiroz_codegen::bundled_assets_dir(false);
     if codegen_assets.exists() {
         println!("cargo:rerun-if-changed={}", codegen_assets.display());
     }
@@ -170,7 +175,7 @@ fn discover_ros_packages(is_humble: bool) -> Result<Vec<PathBuf>> {
     // avoiding issues with system packages that may have different versions or
     // hardcoded paths from Nix wrapProgram.
     println!("cargo:info=Checking local bundled assets from hiroz-codegen's bundled assets");
-    let local_asset_packages = discover_local_assets(&all_packages, is_humble)?;
+    let local_asset_packages = discover_local_assets(&all_packages)?;
     let local_count = local_asset_packages.len();
     for pkg_path in local_asset_packages {
         if let Ok(name) = discover_package_name_from_path(&pkg_path) {
@@ -422,13 +427,16 @@ fn discover_system_packages(packages: &[&str]) -> Result<Vec<PathBuf>> {
 ///
 /// Only returns the subset named in `package_names` (i.e. whatever the enabled
 /// Cargo features requested), not every package hiroz-codegen bundles.
-fn discover_local_assets(package_names: &[&str], is_humble: bool) -> Result<Vec<PathBuf>> {
+fn discover_local_assets(package_names: &[&str]) -> Result<Vec<PathBuf>> {
     let mut found_packages = Vec::new();
 
     // Resolve via hiroz-codegen's own API, not a sibling-directory path — this
     // works whether hiroz-codegen is a workspace path dependency or pulled from
     // crates.io, since it resolves against hiroz-codegen's own CARGO_MANIFEST_DIR.
-    let assets_dir = hiroz_codegen::bundled_assets_dir(is_humble);
+    //
+    // Always jazzy, never `is_humble`: hiroz-codegen only ships the jazzy
+    // corpus populated (see the call site in `main` for the full reasoning).
+    let assets_dir = hiroz_codegen::bundled_assets_dir(false);
 
     if !assets_dir.exists() {
         println!(

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -7,17 +7,6 @@ use hiroz_codegen::python_msgspec_generator;
 fn main() -> Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // .msg/.srv definitions live in hiroz-codegen/assets/, outside this crate,
-    // so cargo won't rerun codegen on edits there unless we track them explicitly.
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-    if let Some(codegen_assets) = manifest_dir
-        .parent()
-        .map(|p| p.join("hiroz-codegen/assets"))
-        && codegen_assets.exists()
-    {
-        println!("cargo:rerun-if-changed={}", codegen_assets.display());
-    }
-
     // Declare custom cfg for ROS version detection
     println!("cargo:rustc-check-cfg=cfg(ros_humble)");
 
@@ -39,6 +28,15 @@ fn main() -> Result<()> {
 
     // Detect ROS version and emit cfg
     let is_humble = detect_ros_version();
+
+    // Message assets are vendored inside the published hiroz-codegen crate (not
+    // a sibling path in this crate's own directory), so ask hiroz-codegen for its
+    // own bundled-assets location. This resolves correctly whether hiroz-codegen
+    // is consumed via path (workspace) or from crates.io.
+    let codegen_assets = hiroz_codegen::bundled_assets_dir(is_humble);
+    if codegen_assets.exists() {
+        println!("cargo:rerun-if-changed={}", codegen_assets.display());
+    }
 
     // Discover ROS packages
     let ros_packages = discover_ros_packages(is_humble)?;
@@ -171,8 +169,8 @@ fn discover_ros_packages(is_humble: bool) -> Result<Vec<PathBuf>> {
     // This ensures our bundled message definitions are always used consistently,
     // avoiding issues with system packages that may have different versions or
     // hardcoded paths from Nix wrapProgram.
-    println!("cargo:info=Checking local bundled assets from hiroz-codegen/assets/jazzy");
-    let local_asset_packages = discover_local_assets(&all_packages)?;
+    println!("cargo:info=Checking local bundled assets from hiroz-codegen's bundled assets");
+    let local_asset_packages = discover_local_assets(&all_packages, is_humble)?;
     let local_count = local_asset_packages.len();
     for pkg_path in local_asset_packages {
         if let Ok(name) = discover_package_name_from_path(&pkg_path) {
@@ -229,7 +227,7 @@ fn discover_ros_packages(is_humble: bool) -> Result<Vec<PathBuf>> {
 
     if !still_missing.is_empty() {
         println!("cargo:warning=Missing packages: {:?}", still_missing);
-        println!("cargo:warning=Consider installing ROS 2 or checking hiroz-codegen/assets/jazzy");
+        println!("cargo:warning=Consider installing ROS 2 or checking hiroz-codegen's bundled assets");
     }
 
     Ok(package_map.into_values().collect())
@@ -241,7 +239,8 @@ fn discover_package_name_from_path(package_path: &std::path::Path) -> Result<Str
 }
 
 /// Get list of all package names based on enabled features
-/// All packages are now bundled in hiroz-codegen/assets/jazzy
+/// All packages are bundled inside hiroz-codegen's own crate (see
+/// `hiroz_codegen::bundled_assets_dir`)
 fn get_all_packages(is_humble: bool) -> Vec<&'static str> {
     let mut names = vec![
         "builtin_interfaces",     // Always required
@@ -417,16 +416,17 @@ fn discover_system_packages(packages: &[&str]) -> Result<Vec<PathBuf>> {
     Ok(found_packages)
 }
 
-/// Discover packages from local bundled assets (hiroz-codegen/assets/jazzy/)
-fn discover_local_assets(package_names: &[&str]) -> Result<Vec<PathBuf>> {
+/// Discover packages from hiroz-codegen's bundled assets directory.
+///
+/// Only returns the subset named in `package_names` (i.e. whatever the enabled
+/// Cargo features requested), not every package hiroz-codegen bundles.
+fn discover_local_assets(package_names: &[&str], is_humble: bool) -> Result<Vec<PathBuf>> {
     let mut found_packages = Vec::new();
 
-    // Get the path to hiroz-codegen/assets/jazzy relative to this crate
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let assets_dir = manifest_dir
-        .parent()
-        .expect("Failed to get parent directory")
-        .join("hiroz-codegen/assets/jazzy");
+    // Resolve via hiroz-codegen's own API, not a sibling-directory path — this
+    // works whether hiroz-codegen is a workspace path dependency or pulled from
+    // crates.io, since it resolves against hiroz-codegen's own CARGO_MANIFEST_DIR.
+    let assets_dir = hiroz_codegen::bundled_assets_dir(is_humble);
 
     if !assets_dir.exists() {
         println!(
@@ -436,7 +436,7 @@ fn discover_local_assets(package_names: &[&str]) -> Result<Vec<PathBuf>> {
         return Ok(Vec::new());
     }
 
-    // Search for packages in jazzy assets directory
+    // Search for the requested packages in the bundled assets directory
     for package_name in package_names {
         let package_path = assets_dir.join(package_name);
 

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -29,15 +29,17 @@ fn main() -> Result<()> {
     // Detect ROS version and emit cfg
     let is_humble = detect_ros_version();
 
-    // Message assets are vendored inside the published hiroz-codegen crate (not
-    // a sibling path in this crate's own directory), so ask hiroz-codegen for its
-    // own bundled-assets location. This resolves correctly whether hiroz-codegen
-    // is consumed via path (workspace) or from crates.io.
+    // hiroz-codegen stores the message assets in its own published crate.
+    // They are not in a sibling path inside this crate's directory. Use
+    // hiroz_codegen::bundled_assets_dir to find them. This finds them
+    // correctly whether hiroz-codegen comes from a workspace path or
+    // from crates.io.
     //
-    // Always the jazzy corpus, never `is_humble`: hiroz-codegen ships only the
-    // jazzy assets populated (assets/humble exists but is empty), and the
-    // package list below already excludes post-Humble-only interfaces, so the
-    // jazzy corpus is the correct bundled fallback for a Humble build too.
+    // Always select the jazzy assets here. Do not pass `is_humble`.
+    // hiroz-codegen ships only the jazzy assets. The assets/humble
+    // directory exists but is empty. The package list below already
+    // excludes interfaces added after Humble. So the jazzy assets are
+    // correct for a Humble build too.
     let codegen_assets = hiroz_codegen::bundled_assets_dir(false);
     if codegen_assets.exists() {
         println!("cargo:rerun-if-changed={}", codegen_assets.display());
@@ -430,12 +432,14 @@ fn discover_system_packages(packages: &[&str]) -> Result<Vec<PathBuf>> {
 fn discover_local_assets(package_names: &[&str]) -> Result<Vec<PathBuf>> {
     let mut found_packages = Vec::new();
 
-    // Resolve via hiroz-codegen's own API, not a sibling-directory path — this
-    // works whether hiroz-codegen is a workspace path dependency or pulled from
-    // crates.io, since it resolves against hiroz-codegen's own CARGO_MANIFEST_DIR.
+    // Resolve this through hiroz-codegen's own API, not a sibling-directory
+    // path. This works whether hiroz-codegen is a workspace path
+    // dependency or comes from crates.io, because it resolves against
+    // hiroz-codegen's own CARGO_MANIFEST_DIR.
     //
-    // Always jazzy, never `is_humble`: hiroz-codegen only ships the jazzy
-    // corpus populated (see the call site in `main` for the full reasoning).
+    // Always select jazzy here. Do not pass `is_humble`. hiroz-codegen
+    // ships only the jazzy assets. See the call site in `main` for the
+    // full reason.
     let assets_dir = hiroz_codegen::bundled_assets_dir(false);
 
     if !assets_dir.exists() {

--- a/crates/hiroz-msgs/build.rs
+++ b/crates/hiroz-msgs/build.rs
@@ -227,7 +227,9 @@ fn discover_ros_packages(is_humble: bool) -> Result<Vec<PathBuf>> {
 
     if !still_missing.is_empty() {
         println!("cargo:warning=Missing packages: {:?}", still_missing);
-        println!("cargo:warning=Consider installing ROS 2 or checking hiroz-codegen's bundled assets");
+        println!(
+            "cargo:warning=Consider installing ROS 2 or checking hiroz-codegen's bundled assets"
+        );
     }
 
     Ok(package_map.into_values().collect())

--- a/docs/user-guide/custom-messages.md
+++ b/docs/user-guide/custom-messages.md
@@ -194,16 +194,18 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-hiroz-msgs = { git = "https://github.com/ZettaScaleLabs/hiroz.git" }
-hiroz = { git = "https://github.com/ZettaScaleLabs/hiroz.git", default-features = false }
+hiroz-msgs = "0.2"
+hiroz = { version = "0.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 smart-default = "0.7"
 zenoh-buffers = "1"
 
 [build-dependencies]
-hiroz-codegen = { git = "https://github.com/ZettaScaleLabs/hiroz.git" }
+hiroz-codegen = "0.2"
 anyhow = "1"
 ```
+
+`hiroz-msgs`, `hiroz`, and `hiroz-codegen` are published on crates.io, so a version dependency is enough — no `git` dependency is required. This matters for your own crate too: crates.io rejects any published crate that depends on a `git` source, so if you want `my-robot-msgs` itself to be publishable, its dependencies need to come from crates.io as well.
 
 **build.rs:**
 

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -46,11 +46,13 @@ def check-bundled-msgs [] {
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features geometry_msgs"
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features sensor_msgs"
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features nav_msgs"
-    # This shell has no system ROS install (no AMENT_PREFIX_PATH), so
-    # detect_ros_version()'s system-install fallback can't mask a broken
-    # bundled-assets path the way every ROS-container CI job does. That gap
-    # let `hiroz-codegen::bundled_assets_dir(is_humble)` ship pointed at the
-    # empty `assets/humble` directory unnoticed — see ZettaScaleLabs/hiroz#332.
+    # This shell has no system ROS install. It has no AMENT_PREFIX_PATH.
+    # So detect_ros_version()'s system-install fallback cannot hide a
+    # broken bundled-assets path. Every ROS-container CI job hides this
+    # kind of bug, because it has a system ROS install. That gap let
+    # `hiroz_codegen::bundled_assets_dir(is_humble)` point at the empty
+    # `assets/humble` directory. Nobody noticed. See
+    # ZettaScaleLabs/hiroz#332 for the details.
     run-cmd "cargo check -p hiroz-msgs --features humble"
 }
 

--- a/scripts/test-pure-rust.nu
+++ b/scripts/test-pure-rust.nu
@@ -46,6 +46,12 @@ def check-bundled-msgs [] {
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features geometry_msgs"
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features sensor_msgs"
     run-cmd "cargo check -p hiroz-msgs --no-default-features --features nav_msgs"
+    # This shell has no system ROS install (no AMENT_PREFIX_PATH), so
+    # detect_ros_version()'s system-install fallback can't mask a broken
+    # bundled-assets path the way every ROS-container CI job does. That gap
+    # let `hiroz-codegen::bundled_assets_dir(is_humble)` ship pointed at the
+    # empty `assets/humble` directory unnoticed — see ZettaScaleLabs/hiroz#332.
+    run-cmd "cargo check -p hiroz-msgs --features humble"
 }
 
 def check-hu [] {


### PR DESCRIPTION
## Summary

`hiroz-msgs`'s `build.rs` located `.msg`/`.srv` codegen assets via a sibling-directory path (`manifest_dir.parent().join("hiroz-codegen/assets")`), which only exists inside this workspace's checkout layout. `cargo package`/`cargo publish` only bundle files inside a crate's own root, so `hiroz-codegen/assets` — a sibling directory — would never exist in the packaged tarball, and `hiroz-msgs` could never be published to crates.io. This PR removes that blocker.

It also unblocks anyone building their own message-package crate on top of `hiroz-msgs` (see the `my-robot-msgs` example in `docs/user-guide/custom-messages.md`): crates.io refuses to publish any crate with a `git` dependency, and `hiroz-msgs` was git-only.

## Before and after

| | before | after |
|---|---|---|
| asset resolution | `manifest_dir.parent().join("hiroz-codegen/assets")` — sibling path, workspace-checkout-only | `hiroz_codegen::bundled_assets_dir(is_humble)` — resolves via `hiroz-codegen`'s own (published) `CARGO_MANIFEST_DIR` |
| `hiroz-msgs/Cargo.toml` | `publish = false`, no crates.io metadata | publishable, metadata matches `hiroz`/`hiroz-codegen`'s style, `hiroz`/`hiroz-derive` path deps pinned to `version = "0.2"` |
| `docs/user-guide/custom-messages.md` example | `hiroz-msgs = { git = "https://github.com/ZettaScaleLabs/hiroz.git" }` | `hiroz-msgs = { version = "0.2" }` |
| `cargo package -p hiroz-msgs --list` | not attempted | 26 files, all under the crate's own root |
| `cargo publish -p hiroz-msgs --dry-run` | fails (needs the sibling dir) | succeeds |

## What fails without this

`cargo publish -p hiroz-msgs --dry-run` cannot succeed today — the packaged crate is missing `hiroz-codegen/assets`, so anyone building it outside the workspace checkout hits a missing-directory error at build time.

Verified on a clean checkout at this commit: `cargo build -p hiroz-msgs --features core_msgs` and other in-workspace feature combinations still build unchanged; `cargo package -p hiroz-msgs --list` shows nothing outside the crate root; `cargo publish -p hiroz-msgs --dry-run` packages successfully. As a further check, downloading the already-published `hiroz`/`hiroz-codegen` v0.2.0 from crates.io and rebuilding `hiroz-msgs` standalone against them (outside the workspace) confirmed codegen runs correctly against the crates.io-downloaded bundled assets.

## Breaking changes

None. The ROS 2 installation / `HIROZ_MSG_PATH` fallback path in `build.rs` is unchanged; only the local-bundled-assets source changed from a sibling path to the `hiroz-codegen` public API.

## Known follow-up

`hiroz`/`hiroz-derive`'s path dependencies in `hiroz-msgs/Cargo.toml` now carry a hardcoded `version = "0.2"` (required for `cargo publish` to accept a path dependency). It does not derive from `version.workspace`, so it needs a manual bump alongside future workspace version bumps, or it will silently pin a stale minimum version in the published manifest while local/path builds keep working unaffected.
