### PR TITLE
fix: typehash mismatch nested  .action msg

### DIFF
--- a/crates/hiroz-codegen/src/resolver.rs
+++ b/crates/hiroz-codegen/src/resolver.rs
@@ -517,6 +517,8 @@ impl Resolver {
         // Add goal type description
         let goal_desc = goal.type_description();
         deps.insert(goal_desc.type_name.clone(), goal_desc.clone());
+        self.collect_nested_deps(&goal_desc, &mut deps);
+        
 
         // Calculate action service hash (uses /action/ path instead of /srv/)
         let service_hash = crate::hashing::calculate_service_type_hash(
@@ -622,6 +624,7 @@ impl Resolver {
         // Add result type description
         let result_desc = result.type_description();
         deps.insert(result_desc.type_name.clone(), result_desc.clone());
+        self.collect_nested_deps(&result_desc, &mut deps);
 
         // Calculate action service hash
         let service_hash = crate::hashing::calculate_service_type_hash(
@@ -681,7 +684,8 @@ impl Resolver {
 
         // Add feedback type description
         let feedback_desc = feedback.type_description();
-        deps.insert(feedback_desc.type_name.clone(), feedback_desc);
+        deps.insert(feedback_desc.type_name.clone(), feedback_desc.clone());
+        self.collect_nested_deps(&feedback_desc, &mut deps);
 
         // Build TypeDescriptionMsg and calculate hash
         use crate::hashing::{TypeDescriptionMsg, to_hash_version, to_ros2_json};


### PR DESCRIPTION
## Description

Fix missing nested-dependency collection in action Goal/Result/Feedback type hashing

calculate_send_goal_hash, calculate_get_result_hash, and calculate_feedback_message_hash in hiroz-codegen's Resolver each insert the action's Goal/Result/Feedback TypeDescription into the deps map used to compute the corresponding RIHS01 type hash, but never call the existing collect_nested_deps helper to also pull in that type's own nested/referenced message dependencies. calculate_service_type_hash performs no recursive expansion of its own — it hashes exactly the flattened referenced_type_descriptions it's given — so any action whose Goal, Result, or Feedback message references a custom nested message type (e.g. a struct field typed as another message, not just primitives) gets an incomplete dependency set and therefore an incorrect RIHS01 hash.



## Checklist

- [ ] Ran `./scripts/check-local.sh` successfully
- [ ] Added/updated tests/documentation (if applicable)

---

**External contributors:** Please open as **draft** initially. See [CONTRIBUTING.md](https://github.com/ZettaScaleLabs/hiroz/blob/main/CONTRIBUTING.md#pull-request-guidelines).
