### PR TITLE
fix: collect nested deps for action Goal/Result/Feedback hashing

### DIFF
--- a/crates/hiroz-codegen/src/resolver.rs
+++ b/crates/hiroz-codegen/src/resolver.rs
@@ -518,7 +518,6 @@ impl Resolver {
         let goal_desc = goal.type_description();
         deps.insert(goal_desc.type_name.clone(), goal_desc.clone());
         self.collect_nested_deps(&goal_desc, &mut deps);
-        
 
         // Calculate action service hash (uses /action/ path instead of /srv/)
         let service_hash = crate::hashing::calculate_service_type_hash(

--- a/crates/hiroz-codegen/src/resolver.rs
+++ b/crates/hiroz-codegen/src/resolver.rs
@@ -517,6 +517,8 @@ impl Resolver {
         // Add goal type description
         let goal_desc = goal.type_description();
         deps.insert(goal_desc.type_name.clone(), goal_desc.clone());
+        self.collect_nested_deps(&goal_desc, &mut deps);
+        
 
         // Calculate action service hash (uses /action/ path instead of /srv/)
         let service_hash = crate::hashing::calculate_service_type_hash(
@@ -622,6 +624,7 @@ impl Resolver {
         // Add result type description
         let result_desc = result.type_description();
         deps.insert(result_desc.type_name.clone(), result_desc.clone());
+        self.collect_nested_deps(&result_desc, &mut deps);
 
         // Calculate action service hash
         let service_hash = crate::hashing::calculate_service_type_hash(
@@ -681,7 +684,8 @@ impl Resolver {
 
         // Add feedback type description
         let feedback_desc = feedback.type_description();
-        deps.insert(feedback_desc.type_name.clone(), feedback_desc);
+        deps.insert(feedback_desc.type_name.clone(), feedback_desc.clone());
+        self.collect_nested_deps(&feedback_desc, &mut deps);
 
         // Build TypeDescriptionMsg and calculate hash
         use crate::hashing::{TypeDescriptionMsg, to_hash_version, to_ros2_json};

--- a/crates/hiroz-codegen/tests/action_nested_deps.rs
+++ b/crates/hiroz-codegen/tests/action_nested_deps.rs
@@ -1,0 +1,83 @@
+//! Action Goal/Result/Feedback type hashing must include nested message
+//! dependencies, the same way plain service hashing already does.
+//!
+//! `tf2_msgs/LookupTransform` exercises both affected paths with one real,
+//! already-packaged fixture -- no synthetic types needed:
+//! - Result (`geometry_msgs/TransformStamped transform`, `tf2_msgs/TF2Error
+//!   error`): `TransformStamped` nests `std_msgs/Header` and
+//!   `geometry_msgs/Transform`, and `Transform` itself nests
+//!   `Vector3`/`Quaternion` -- multi-level nesting `calculate_get_result_hash`
+//!   silently dropped from its dependency set.
+//! - Goal (`builtin_interfaces/Duration timeout`, among primitives):
+//!   `Duration` is a nested dependency `calculate_send_goal_hash` never
+//!   inserted manually (unlike `builtin_interfaces/Time`, which every
+//!   action hash function adds by hand for the goal_id UUID) -- it was only
+//!   ever reachable via `collect_nested_deps`.
+//!
+//! Both were fixed by wiring `collect_nested_deps` into `resolver.rs`
+//! (fj#158, GitHub#334).
+
+use std::path::PathBuf;
+
+fn assets_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/jazzy")
+}
+
+#[test]
+fn test_lookup_transform_hashes_include_nested_deps() {
+    use hiroz_codegen::{
+        discovery::{discover_actions, discover_messages},
+        resolver::Resolver,
+    };
+
+    let assets = assets_dir();
+    let packages = [
+        "builtin_interfaces",
+        "unique_identifier_msgs",
+        "action_msgs",
+        "service_msgs",
+        "std_msgs",
+        "geometry_msgs",
+        "tf2_msgs",
+    ];
+    let mut all_messages = Vec::new();
+    for pkg in &packages {
+        let pkg_path = assets.join(pkg);
+        let msgs = discover_messages(&pkg_path, pkg).unwrap_or_default();
+        all_messages.extend(msgs);
+    }
+
+    let mut resolver = Resolver::new(false);
+    resolver
+        .resolve_messages(all_messages)
+        .expect("resolve messages");
+
+    let pkg_path = assets.join("tf2_msgs");
+    let actions = discover_actions(&pkg_path, "tf2_msgs").expect("discover actions");
+    let resolved = resolver.resolve_actions(actions).expect("resolve actions");
+    let lookup_transform = resolved
+        .iter()
+        .find(|a| a.parsed.name == "LookupTransform")
+        .expect("LookupTransform action");
+
+    // Pinned after fixing calculate_get_result_hash to call
+    // collect_nested_deps on the Result type, matching the plain-service
+    // path (resolver.rs:181-182). Before that fix this hash is computed
+    // over an incomplete dependency set (missing TransformStamped's own
+    // nested Header/Transform/Vector3/Quaternion types) and differs from
+    // this value -- this test must fail on unfixed code.
+    assert_eq!(
+        lookup_transform.get_result_hash.to_rihs_string(),
+        "RIHS01_3cd1715751899e3167b5aec3e4ac194f7da9e8493a77285f9f6a4c914f5e8b24",
+        "get_result hash mismatch -- nested dependency collection regressed"
+    );
+
+    // Same defect, the Goal side: calculate_send_goal_hash never inserted
+    // builtin_interfaces/Duration -- the Goal's `timeout` field -- so it
+    // was only ever reachable via collect_nested_deps too.
+    assert_eq!(
+        lookup_transform.send_goal_hash.to_rihs_string(),
+        "RIHS01_4646ff5706c86b04d0a1098d329951a9731a7517e16702905de6073cc72c8530",
+        "send_goal hash mismatch -- nested dependency collection regressed"
+    );
+}


### PR DESCRIPTION
Fixes the nested-dependency-collection defect #334 reported.

A community pull request (#334, draft) from @sathak93 reported a real defect and diagnosed and fixed it correctly, but shipped no test coverage. This preserves their original commit (cherry-picked, authorship intact) and adds the regression test the diagnosis needed on top.

`calculate_send_goal_hash`, `calculate_get_result_hash`, and `calculate_feedback_message_hash` in `crates/hiroz-codegen/src/resolver.rs` each insert the action's Goal/Result/Feedback `TypeDescription` into the `deps` map used to compute its RIHS01 type hash, but never call `collect_nested_deps` to also pull in that type's own nested/referenced message dependencies — unlike plain service hashing, which already does this (`resolver.rs:181-182`).

## Before and after

| | today | with this change |
|---|---|---|
| action Goal/Result/Feedback with no nested custom message | correct hash (empty nested-deps set is also the correct set) | unchanged |
| action Goal/Result/Feedback referencing a nested custom message | `deps` omits the nested type; RIHS01 hash is wrong | `collect_nested_deps` pulls in the nested type, matching the plain-service code path |

## What the test does

`crates/hiroz-codegen/tests/action_nested_deps.rs` (new) uses `tf2_msgs/LookupTransform`'s Result (`geometry_msgs/TransformStamped transform`, `tf2_msgs/TF2Error error`), a real fixture already packaged under `assets/jazzy/` — no new asset files needed. `TransformStamped` nests `std_msgs/Header` and `geometry_msgs/Transform`, and `Transform` itself nests `Vector3`/`Quaternion`, so this exercises multi-level recursive nesting, not just a single level.

| | today | with this change |
|---|---|---|
| `test_lookup_transform_get_result_hash_includes_nested_deps` | did not exist; the equivalent unfixed code computes `RIHS01_d21f340b...` (whippet job 4383) | new; pins the corrected hash `RIHS01_3cd17157...` (whippet job 4384), computed over the complete dependency set |

Existing action-hash coverage (`action_hash_check.rs`'s `Fibonacci` test) could not have caught this — `Fibonacci`'s Result (`int32[] sequence`) has no nested custom message type.

Verified standalone: `cargo test -p hiroz-codegen --lib --tests` — all green (whippet 4385). `cargo clippy -p hiroz-codegen --all-targets -- -D warnings` — clean.

## Breaking changes

None to the public API. The RIHS01 hash for any action whose Goal/Result/Feedback references a nested custom message type changes — this is the fix, not a regression: the old hash was computed over an incomplete dependency set and would not interoperate with a real `rmw_zenoh_cpp` peer using the same action definition.


