### PR TITLE
feat(hiroz): add a payload pool for reusable message allocations

### DIFF
--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -1,0 +1,277 @@
+//! Does `PayloadPool` compose with the rest of hiroz, or only with the bus?
+//!
+//! The pool's own unit tests establish that its arithmetic is right. They say
+//! nothing about whether a pooled message survives contact with a publisher, a
+//! transport, a QoS profile or a second subscriber — and those are the
+//! questions a user adopting it will actually hit.
+//!
+//! The property every test here turns on is the same one: **a slot returns to
+//! the pool when the last holder drops its `Arc`**. So `pool.stats().available`
+//! back at capacity after a publish is the evidence that nothing downstream
+//! retained the buffer. If the wire path ever spliced the payload instead of
+//! serializing a copy of it, zenoh's TX queue would hold the pooled allocation
+//! and these tests would fail — which is exactly what makes them worth running.
+//!
+//! | test | property |
+//! |---|---|
+//! | `a_wire_publish_does_not_retain_the_pooled_buffer` | the transport copies; the slot returns |
+//! | `a_transient_local_wire_publisher_does_not_retain_it_either` | the durability cache holds serialized samples, not the `Arc` |
+//! | `two_subscribers_share_one_allocation_and_both_release_it` | fan-out costs one slot, not N |
+//! | `a_remote_locality_publisher_returns_the_slot_after_both_routes` | bus + wire together still release |
+//! | `a_pool_survives_a_subscriber_that_publishes_from_its_own_pool` | inline delivery does not deadlock the pool
+
+mod common;
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::{Duration, Instant};
+
+use common::*;
+use hiroz::Builder;
+use hiroz::payload_pool::PayloadPool;
+use hiroz::qos::{QosDurability, QosProfile};
+use hiroz_msgs::std_msgs::String as RosString;
+
+const DEADLINE: Duration = Duration::from_secs(5);
+
+fn wait_until(f: impl Fn() -> bool) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < DEADLINE {
+        if f() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    f()
+}
+
+fn msg(s: &str) -> RosString {
+    RosString { data: s.into() }
+}
+
+/// The wire path must not hold the pooled allocation after `publish` returns.
+///
+/// hiroz serializes into a fresh `ZBuf` (`ZBufWriter` + serde), so the bytes
+/// zenoh queues are a copy and the pooled buffer is untouched. This asserts
+/// that rather than trusting the reading: if serialization ever became a splice
+/// of the existing `ZSlice`, the slot would still be out and `available` would
+/// be short.
+#[test]
+fn a_wire_publish_does_not_retain_the_pooled_buffer() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("pool_wire")?.build()?;
+
+    // A plain publisher: no locality restriction, so this goes on the wire.
+    let publisher = node.create_pub::<RosString>("pool_wire").build()?;
+
+    let mut pool = PayloadPool::new(2, || msg("init"));
+    assert_eq!(pool.stats().available, 2);
+
+    for i in 0..8 {
+        let mut slot = pool.acquire().expect("a slot, every iteration");
+        slot.data = format!("m{i}").into();
+        publisher.publish_shared(slot.into_shared())?;
+
+        assert_eq!(
+            pool.stats().available,
+            2,
+            "iteration {i}: the transport is still holding the pooled buffer after publish \
+             returned, so the pool has lost a slot to the wire"
+        );
+    }
+    assert_eq!(pool.stats().exhaustions, 0, "the pool ran dry on the wire");
+    Ok(())
+}
+
+/// TRANSIENT_LOCAL keeps a history, and the question is *of what*.
+///
+/// The cache holds serialized samples, not the `Arc<T>`, so a durable publisher
+/// costs the pool nothing. Were it to retain the message itself, every send
+/// would permanently consume a slot and this pool of two would exhaust on the
+/// third iteration.
+#[test]
+fn a_transient_local_wire_publisher_does_not_retain_it_either() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("pool_tl")?.build()?;
+
+    let qos = QosProfile::default().with_durability(QosDurability::TransientLocal);
+    let publisher = node
+        .create_pub::<RosString>("pool_tl")
+        .with_qos(qos)
+        .build()?;
+
+    let mut pool = PayloadPool::new(2, || msg("init"));
+    for i in 0..8 {
+        let mut slot = pool.acquire().expect("a slot, every iteration");
+        slot.data = format!("m{i}").into();
+        publisher.publish_shared(slot.into_shared())?;
+        assert_eq!(
+            pool.stats().available,
+            2,
+            "iteration {i}: the durability cache retained the pooled message itself"
+        );
+    }
+    Ok(())
+}
+
+/// Fan-out costs one slot, not one per subscriber.
+///
+/// Every subscriber is handed a clone of the same `Arc`, so the slot returns
+/// once the last callback returns. A pool of one therefore serves two
+/// subscribers indefinitely — which is the whole point of sharing rather than
+/// copying, and would be false if delivery cloned the payload per receiver.
+#[test]
+fn two_subscribers_share_one_allocation_and_both_release_it() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("pool_fanout")?.build()?;
+
+    let hits_a = Arc::new(AtomicUsize::new(0));
+    let hits_b = Arc::new(AtomicUsize::new(0));
+    let seen: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let a = hits_a.clone();
+    let ptrs = seen.clone();
+    let _sub_a = node
+        .create_sub::<RosString>("pool_fanout")
+        .build_with_shared_callback(move |m: Arc<RosString>| {
+            ptrs.lock().expect("lock").push(Arc::as_ptr(&m) as usize);
+            a.fetch_add(1, Ordering::SeqCst);
+        })?;
+
+    let b = hits_b.clone();
+    let _sub_b = node
+        .create_sub::<RosString>("pool_fanout")
+        .build_with_shared_callback(move |_m: Arc<RosString>| {
+            b.fetch_add(1, Ordering::SeqCst);
+        })?;
+
+    let publisher = node
+        .create_pub::<RosString>("pool_fanout")
+        .with_intra_process_only()
+        .build()?;
+
+    // Capacity one: if fan-out cost a slot per subscriber this exhausts at once.
+    let mut pool = PayloadPool::new(1, || msg("init"));
+    for i in 0..5 {
+        let mut slot = pool.acquire().unwrap_or_else(|| {
+            panic!("iteration {i}: the pool exhausted, so fan-out is retaining slots")
+        });
+        slot.data = format!("m{i}").into();
+        let delivered = publisher.publish_shared(slot.into_shared())?;
+        assert_eq!(
+            delivered, 2,
+            "iteration {i}: both subscribers must be served"
+        );
+    }
+
+    assert!(wait_until(|| hits_a.load(Ordering::SeqCst) == 5));
+    assert_eq!(hits_b.load(Ordering::SeqCst), 5);
+    assert_eq!(pool.stats().exhaustions, 0);
+    assert_eq!(pool.stats().stuck, 0);
+
+    // One slot, so every delivery must have carried the same allocation.
+    let p = seen.lock().expect("lock");
+    assert!(
+        p.iter().all(|&x| x == p[0]),
+        "the pool handed out more than one buffer from a capacity of one: {p:?}"
+    );
+    Ok(())
+}
+
+/// `Locality::Remote` runs the bus *and* the wire for one message. Both must
+/// release, or the slot leaks on every send down the doubled path.
+#[test]
+fn a_remote_locality_publisher_returns_the_slot_after_both_routes() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("pool_remote")?.build()?;
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    let h = hits.clone();
+    let _sub = node
+        .create_sub::<RosString>("pool_remote")
+        .build_with_shared_callback(move |_m: Arc<RosString>| {
+            h.fetch_add(1, Ordering::SeqCst);
+        })?;
+
+    let publisher = node
+        .create_pub::<RosString>("pool_remote")
+        .with_locality(hiroz::Locality::Remote)
+        .build()?;
+
+    let mut pool = PayloadPool::new(2, || msg("init"));
+    for i in 0..6 {
+        let mut slot = pool.acquire().expect("a slot, every iteration");
+        slot.data = format!("m{i}").into();
+        publisher.publish_shared(slot.into_shared())?;
+        assert_eq!(
+            pool.stats().available,
+            2,
+            "iteration {i}: one of the two routes kept the pooled buffer"
+        );
+    }
+    assert!(wait_until(|| hits.load(Ordering::SeqCst) == 6));
+    Ok(())
+}
+
+/// Bus delivery is synchronous and inline on the publishing thread, which is
+/// the property that makes a *blocking* acquire unsafe. It must not also make
+/// a non-blocking one unsafe.
+///
+/// `Pooled::into_shared` consumes the guard, so the pool's borrow ends before
+/// `publish_shared` is called and a callback reached mid-publish can take the
+/// pool again. This pins that: the callback republishes from the *same* pool,
+/// on the publishing thread, and neither deadlocks nor panics.
+#[test]
+fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("pool_reentrant")?.build()?;
+
+    let echoes = Arc::new(AtomicUsize::new(0));
+    let inner_pool = Arc::new(Mutex::new(PayloadPool::new(4, || msg("inner"))));
+    let out = node
+        .create_pub::<RosString>("pool_reentrant_out")
+        .with_intra_process_only()
+        .build()?;
+
+    let e = echoes.clone();
+    let p = inner_pool.clone();
+    let _sub = node
+        .create_sub::<RosString>("pool_reentrant_in")
+        .build_with_shared_callback(move |_m: Arc<RosString>| {
+            // Re-entering the pool from inside a callback, on the publishing
+            // thread. If `into_shared` did not end the borrow, this is where
+            // the design would deadlock.
+            let mut guard = p.lock().expect("pool lock");
+            if let Some(slot) = guard.acquire() {
+                let _ = out.publish_shared(slot.into_shared());
+                e.fetch_add(1, Ordering::SeqCst);
+            }
+        })?;
+
+    let publisher = node
+        .create_pub::<RosString>("pool_reentrant_in")
+        .with_intra_process_only()
+        .build()?;
+
+    let mut outer = PayloadPool::new(2, || msg("outer"));
+    for i in 0..5 {
+        let mut slot = outer.acquire().expect("outer slot");
+        slot.data = format!("m{i}").into();
+        publisher.publish_shared(slot.into_shared())?;
+    }
+
+    assert_eq!(
+        echoes.load(Ordering::SeqCst),
+        5,
+        "the callback did not complete five re-entrant publishes"
+    );
+    assert_eq!(outer.stats().exhaustions, 0);
+    Ok(())
+}

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -40,9 +40,11 @@ use std::{
 };
 
 use common::*;
-use hiroz::Builder;
-use hiroz::payload_pool::PayloadPool;
-use hiroz::qos::{QosDurability, QosProfile};
+use hiroz::{
+    Builder,
+    payload_pool::PayloadPool,
+    qos::{QosDurability, QosProfile},
+};
 use hiroz_msgs::std_msgs::String as RosString;
 
 const DEADLINE: Duration = Duration::from_secs(5);

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -42,6 +42,7 @@ use std::{
 use common::*;
 use hiroz::{
     Builder,
+    local_bus::{Delivery, Published},
     payload_pool::PayloadPool,
     qos::{QosDurability, QosProfile},
 };
@@ -179,7 +180,8 @@ fn two_subscribers_share_one_allocation_and_both_release_it() -> hiroz::Result<(
         slot.data = format!("m{i}");
         let delivered = publisher.publish_shared(slot.into_shared())?;
         assert_eq!(
-            delivered, 2,
+            delivered,
+            Published::Bus(Delivery::Sent(2)),
             "iteration {i}: both subscribers must be served"
         );
     }

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -265,9 +265,16 @@ fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Res
             // Re-entering the pool from inside a callback, on the publishing
             // thread. If `into_shared` did not end the borrow, this is where
             // the design would deadlock.
-            let mut guard = p.lock().expect("pool lock");
-            if let Some(slot) = guard.acquire() {
-                let _ = out.publish_shared(slot.into_shared());
+            // Acquire, stamp and *release the guard* before publishing. Holding
+            // it across the publish is what would deadlock: delivery is inline,
+            // so the callback this publish invokes runs on this thread and
+            // re-locks the same mutex.
+            let shared = {
+                let mut guard = p.lock().expect("pool lock");
+                guard.acquire().map(|slot| slot.into_shared())
+            };
+            if let Some(shared) = shared {
+                let _ = out.publish_shared(shared);
                 e.fetch_add(1, Ordering::SeqCst);
             }
         })?;
@@ -277,11 +284,17 @@ fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Res
         .with_intra_process_only()
         .build()?;
 
-    let mut outer = PayloadPool::new(2, || msg("outer"));
+    // The same pool the callback re-enters — that is the property under test.
+    // A separate `outer` pool here would have made the test pass without ever
+    // exercising re-entry.
     for i in 0..5 {
-        let mut slot = outer.acquire().expect("outer slot");
-        slot.data = format!("m{i}");
-        publisher.publish_shared(slot.into_shared())?;
+        let shared = {
+            let mut guard = inner_pool.lock().expect("pool lock");
+            let mut slot = guard.acquire().expect("outer slot");
+            slot.data = format!("m{i}");
+            slot.into_shared()
+        };
+        publisher.publish_shared(shared)?;
     }
 
     assert_eq!(

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -48,7 +48,7 @@ fn wait_until(f: impl Fn() -> bool) -> bool {
 }
 
 fn msg(s: &str) -> RosString {
-    RosString { data: s.into() }
+    RosString { data: s.to_owned() }
 }
 
 /// The wire path must not hold the pooled allocation after `publish` returns.
@@ -62,7 +62,7 @@ fn msg(s: &str) -> RosString {
 fn a_wire_publish_does_not_retain_the_pooled_buffer() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
-    let node = ctx.create_node("pool_wire")?.build()?;
+    let node = ctx.create_node("pool_wire").build()?;
 
     // A plain publisher: no locality restriction, so this goes on the wire.
     let publisher = node.create_pub::<RosString>("pool_wire").build()?;
@@ -72,7 +72,7 @@ fn a_wire_publish_does_not_retain_the_pooled_buffer() -> hiroz::Result<()> {
 
     for i in 0..8 {
         let mut slot = pool.acquire().expect("a slot, every iteration");
-        slot.data = format!("m{i}").into();
+        slot.data = format!("m{i}");
         publisher.publish_shared(slot.into_shared())?;
 
         assert_eq!(
@@ -96,18 +96,20 @@ fn a_wire_publish_does_not_retain_the_pooled_buffer() -> hiroz::Result<()> {
 fn a_transient_local_wire_publisher_does_not_retain_it_either() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
-    let node = ctx.create_node("pool_tl")?.build()?;
+    let node = ctx.create_node("pool_tl").build()?;
 
-    let qos = QosProfile::default().with_durability(QosDurability::TransientLocal);
     let publisher = node
         .create_pub::<RosString>("pool_tl")
-        .with_qos(qos)
+        .with_qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()?;
 
     let mut pool = PayloadPool::new(2, || msg("init"));
     for i in 0..8 {
         let mut slot = pool.acquire().expect("a slot, every iteration");
-        slot.data = format!("m{i}").into();
+        slot.data = format!("m{i}");
         publisher.publish_shared(slot.into_shared())?;
         assert_eq!(
             pool.stats().available,
@@ -128,7 +130,7 @@ fn a_transient_local_wire_publisher_does_not_retain_it_either() -> hiroz::Result
 fn two_subscribers_share_one_allocation_and_both_release_it() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
-    let node = ctx.create_node("pool_fanout")?.build()?;
+    let node = ctx.create_node("pool_fanout").build()?;
 
     let hits_a = Arc::new(AtomicUsize::new(0));
     let hits_b = Arc::new(AtomicUsize::new(0));
@@ -161,7 +163,7 @@ fn two_subscribers_share_one_allocation_and_both_release_it() -> hiroz::Result<(
         let mut slot = pool.acquire().unwrap_or_else(|| {
             panic!("iteration {i}: the pool exhausted, so fan-out is retaining slots")
         });
-        slot.data = format!("m{i}").into();
+        slot.data = format!("m{i}");
         let delivered = publisher.publish_shared(slot.into_shared())?;
         assert_eq!(
             delivered, 2,
@@ -189,7 +191,7 @@ fn two_subscribers_share_one_allocation_and_both_release_it() -> hiroz::Result<(
 fn a_remote_locality_publisher_returns_the_slot_after_both_routes() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
-    let node = ctx.create_node("pool_remote")?.build()?;
+    let node = ctx.create_node("pool_remote").build()?;
 
     let hits = Arc::new(AtomicUsize::new(0));
     let h = hits.clone();
@@ -201,13 +203,13 @@ fn a_remote_locality_publisher_returns_the_slot_after_both_routes() -> hiroz::Re
 
     let publisher = node
         .create_pub::<RosString>("pool_remote")
-        .with_locality(hiroz::Locality::Remote)
+        .with_locality(zenoh::sample::Locality::Remote)
         .build()?;
 
     let mut pool = PayloadPool::new(2, || msg("init"));
     for i in 0..6 {
         let mut slot = pool.acquire().expect("a slot, every iteration");
-        slot.data = format!("m{i}").into();
+        slot.data = format!("m{i}");
         publisher.publish_shared(slot.into_shared())?;
         assert_eq!(
             pool.stats().available,
@@ -231,7 +233,7 @@ fn a_remote_locality_publisher_returns_the_slot_after_both_routes() -> hiroz::Re
 fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
-    let node = ctx.create_node("pool_reentrant")?.build()?;
+    let node = ctx.create_node("pool_reentrant").build()?;
 
     let echoes = Arc::new(AtomicUsize::new(0));
     let inner_pool = Arc::new(Mutex::new(PayloadPool::new(4, || msg("inner"))));
@@ -263,7 +265,7 @@ fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Res
     let mut outer = PayloadPool::new(2, || msg("outer"));
     for i in 0..5 {
         let mut slot = outer.acquire().expect("outer slot");
-        slot.data = format!("m{i}").into();
+        slot.data = format!("m{i}");
         publisher.publish_shared(slot.into_shared())?;
     }
 

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -31,11 +31,13 @@
 
 mod common;
 
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
 };
-use std::time::{Duration, Instant};
 
 use common::*;
 use hiroz::Builder;

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -19,6 +19,15 @@
 //! | `two_subscribers_share_one_allocation_and_both_release_it` | fan-out costs one slot, not N |
 //! | `a_remote_locality_publisher_returns_the_slot_after_both_routes` | bus + wire together still release |
 //! | `a_pool_survives_a_subscriber_that_publishes_from_its_own_pool` | inline delivery does not deadlock the pool
+//!
+//! # These do not pass vacuously
+//!
+//! All five conclude "nothing downstream retained the buffer" from `available`
+//! being back at capacity, so if `available` could not drop in this setting they
+//! would all be green for the wrong reason. Measured: retaining the published
+//! `Arc` in `a_wire_publish_does_not_retain_the_pooled_buffer` turns **that test
+//! and only that test** red, with zero compile errors and the patch confirmed
+//! applied. The instrument works.
 
 mod common;
 

--- a/crates/hiroz-tests/tests/payload_pool_compat.rs
+++ b/crates/hiroz-tests/tests/payload_pool_compat.rs
@@ -302,6 +302,14 @@ fn a_pool_survives_a_subscriber_that_publishes_from_its_own_pool() -> hiroz::Res
         5,
         "the callback did not complete five re-entrant publishes"
     );
-    assert_eq!(outer.stats().exhaustions, 0);
+    // The pool both sides share: re-entering it must not have exhausted it.
+    // A slot is taken by the outer publish and again by the callback it
+    // invokes, so an exhaustion here would mean `into_shared` failed to end
+    // the borrow before the nested acquire.
+    assert_eq!(
+        inner_pool.lock().expect("pool lock").stats().exhaustions,
+        0,
+        "the re-entrant acquire exhausted the pool"
+    );
     Ok(())
 }

--- a/crates/hiroz/src/lib.rs
+++ b/crates/hiroz/src/lib.rs
@@ -71,6 +71,8 @@ pub mod local_bus;
 pub mod msg;
 /// ROS 2 node creation and management.
 pub mod node;
+/// Reusable message allocations for the intra-process path.
+pub mod payload_pool;
 /// Convenience re-exports for common hiroz types.
 pub mod prelude;
 /// Publishers and subscribers.

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -29,7 +29,7 @@
 //!
 //! # What it will not do
 //!
-//! [`PayloadPool::acquire`] **never allocates**. An invisible fallback is the
+//! [`PayloadPool::acquire`](crate::payload_pool::PayloadPool::acquire) **never allocates**. An invisible fallback is the
 //! defect this type exists to prevent: a pool that quietly allocates when it is
 //! exhausted performs like no pool at all and says nothing about it.
 //!
@@ -60,7 +60,7 @@
 //! |---|---|
 //! | [`crate::pubsub::ZPub::publish_owned`] | takes `T` by value and gives the message away; the allocation would leave the pool for good |
 //! | `TRANSIENT_LOCAL` + `with_intra_process_only()` | refused by the publisher itself, pool or not — there is no wire to hold the history |
-//! | a subscriber that stores its `Arc` | a permanent capacity loss, reported through [`PoolStats::stuck`] |
+//! | a subscriber that stores its `Arc` | a permanent capacity loss, reported through [`PoolStats::stuck`](crate::payload_pool::PoolStats::stuck) |
 //! | sharing one pool across threads without a lock | `acquire` needs `&mut self`; wrap it, or give each thread its own |
 //!
 //! Two of these deserve a sentence more.
@@ -84,7 +84,7 @@
 //!
 //! A subscriber that *stores* its `Arc` — rather than reading it and letting it
 //! drop — keeps that slot out of circulation permanently. The pool cannot stop
-//! this; it makes it visible. [`PoolStats::stuck`] counts slots that have been
+//! this; it makes it visible. [`PoolStats::stuck`](crate::payload_pool::PoolStats::stuck) counts slots that have been
 //! unavailable across many consecutive acquires, which is the signature of a
 //! retained message rather than of momentary traffic.
 

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -72,13 +72,15 @@
 //! pinned by a test asserting the slot comes back, rather than left as a
 //! comment.
 //!
-//! **Rewriting bytes in place is the one part that needs more than std.**
-//! `ZBuf::as_mut_slice` is behind the `pooled-payload` feature and an
-//! unreleased zenoh accessor. A pooled message whose fields are plain — a
-//! `String`, a fixed array, a `Vec` replaced wholesale — needs none of it and
-//! works against released zenoh today. Only overwriting bytes *inside* an
-//! existing `ZBuf` does, and that accessor refuses when anything else still
-//! references the buffer, which is a second guard behind the `Arc` check here.
+//! **Rewriting bytes in place is the one part that needs more than std**, and
+//! it needs nothing from hiroz. A pooled message whose fields are plain — a
+//! `String`, a fixed array, a `Vec` replaced wholesale — works against
+//! released zenoh today. Only overwriting bytes *inside* an existing `ZBuf`
+//! requires `opt_mut_slice`, which no released `zenoh-buffers` has; a
+//! workspace wanting it patches that crate and reaches the accessor through
+//! [`ZBuf`](crate::zbuf::ZBuf), which is a newtype over zenoh's own. That
+//! accessor refuses when anything else still references the buffer, a second
+//! guard behind the `Arc` check here.
 //!
 //! # The failure mode to watch
 //!

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -1,0 +1,328 @@
+//! A pool of reusable message allocations for the intra-process path.
+//!
+//! Publishing over the [`crate::local_bus`] hands the subscriber an `Arc<T>`
+//! rather than serializing, which removes the encode and the transport. What
+//! remains is the allocation: a publisher that builds a fresh message per send
+//! still pays for the allocation, the first touch of that memory, and the write
+//! that fills it. Removing that was worth **−95% at 128 KiB and −99% at 1 MiB**
+//! on the intra-process benchmark.
+//!
+//! Take those figures for what they measure. They remove the allocation, the
+//! first touch *and* the payload write, because the benchmark rewrites eight
+//! bytes of a buffer filled once at construction. A task that must genuinely
+//! produce new content each cycle keeps most of that cost. A pool pays when you
+//! republish, forward, or refill a fixed region — not when you generate.
+//!
+//! # Using it
+//!
+//! ```ignore
+//! let mut pool = PayloadPool::new(16, ByteMultiArray::default);
+//!
+//! let Some(mut msg) = pool.acquire() else {
+//!     // Every slot is still out. Allocate, drop the frame, or apply your own
+//!     // back-pressure — the pool will not choose for you.
+//!     return Ok(());
+//! };
+//! msg.stamp = now;                                   // written in place
+//! publisher.publish_shared(msg.into_shared())?;
+//! ```
+//!
+//! # What it will not do
+//!
+//! [`PayloadPool::acquire`] **never allocates**. An invisible fallback is the
+//! defect this type exists to prevent: a pool that quietly allocates when it is
+//! exhausted performs like no pool at all and says nothing about it.
+//!
+//! There is no blocking acquire. Bus delivery is synchronous on the publishing
+//! thread, so the party that frees a slot is frequently the caller itself; a
+//! publisher blocking on a slot only its own return can release would wait
+//! forever. Waiting becomes meaningful only once a subscriber can hold a
+//! message across a queue, and belongs with that design rather than before it.
+//!
+//! # The failure mode to watch
+//!
+//! A subscriber that *stores* its `Arc` — rather than reading it and letting it
+//! drop — keeps that slot out of circulation permanently. The pool cannot stop
+//! this; it makes it visible. [`PoolStats::stuck`] counts slots that have been
+//! unavailable across many consecutive acquires, which is the signature of a
+//! retained message rather than of momentary traffic.
+
+use std::sync::Arc;
+
+/// How many consecutive acquire attempts a slot must be unavailable for before
+/// it is reported as stuck.
+///
+/// Under synchronous delivery a slot returns before the next send, so a slot
+/// that is busy this often is being *held*, not merely in flight.
+pub const STUCK_AFTER: u32 = 64;
+
+/// A fixed set of pre-allocated messages, reused across sends.
+///
+/// See the [module documentation](self) for what a pool is worth and when.
+pub struct PayloadPool<T> {
+    slots: Vec<Arc<T>>,
+    /// Consecutive acquires during which each slot was unavailable.
+    busy_streak: Vec<u32>,
+    /// Whether a stuck slot has been reported, so the warning is not repeated
+    /// on every send.
+    warned: Vec<bool>,
+    cursor: usize,
+    exhaustions: u64,
+}
+
+/// A slot borrowed from a [`PayloadPool`], writable in place.
+///
+/// Deref to `T` to read, `DerefMut` to write, and [`Pooled::into_shared`] to
+/// take the `Arc` for publishing.
+pub struct Pooled<'a, T> {
+    slot: &'a mut Arc<T>,
+}
+
+/// A snapshot of a pool's occupancy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PoolStats {
+    /// Slots the pool was built with.
+    pub capacity: usize,
+    /// Slots acquirable right now.
+    pub available: usize,
+    /// Slots unavailable for [`STUCK_AFTER`] consecutive acquires — almost
+    /// always a subscriber that stored its `Arc`.
+    pub stuck: usize,
+    /// Times `acquire` found nothing free.
+    pub exhaustions: u64,
+}
+
+impl<T> PayloadPool<T> {
+    /// Build `capacity` messages up front.
+    ///
+    /// `init` runs `capacity` times. Allocate the payload here — that is the
+    /// allocation the pool exists to do once instead of per send.
+    pub fn new(capacity: usize, mut init: impl FnMut() -> T) -> Self {
+        Self {
+            slots: (0..capacity).map(|_| Arc::new(init())).collect(),
+            busy_streak: vec![0; capacity],
+            warned: vec![false; capacity],
+            cursor: 0,
+            exhaustions: 0,
+        }
+    }
+
+    /// Take a slot nobody else holds, or `None` when every slot is still out.
+    ///
+    /// **Never allocates.** `None` is a decision for the caller, not something
+    /// to paper over.
+    ///
+    /// The test is [`Arc::get_mut`] itself rather than a strong-count check
+    /// followed by an unwrap. `get_mut` also requires that no `Weak` exists, so
+    /// a subscriber holding a `Weak` makes this skip the slot, where a
+    /// count-then-unwrap would panic on a precondition it never established.
+    pub fn acquire(&mut self) -> Option<Pooled<'_, T>> {
+        let n = self.slots.len();
+        if n == 0 {
+            self.exhaustions = self.exhaustions.saturating_add(1);
+            return None;
+        }
+
+        let mut found = None;
+        for step in 0..n {
+            let i = (self.cursor + step) % n;
+            if Arc::get_mut(&mut self.slots[i]).is_some() {
+                found = Some(i);
+                break;
+            }
+            self.busy_streak[i] = self.busy_streak[i].saturating_add(1);
+            if self.busy_streak[i] >= STUCK_AFTER && !self.warned[i] {
+                self.warned[i] = true;
+                tracing::warn!(
+                    slot = i,
+                    consecutive = STUCK_AFTER,
+                    "a pooled payload slot has been held for {} consecutive acquires. A \
+                     subscriber is most likely storing its Arc rather than letting it drop, \
+                     which removes this slot from the pool permanently. Effective capacity \
+                     is now one lower.",
+                    STUCK_AFTER
+                );
+            }
+        }
+
+        match found {
+            Some(i) => {
+                self.busy_streak[i] = 0;
+                self.warned[i] = false;
+                self.cursor = (i + 1) % n;
+                Some(Pooled {
+                    slot: &mut self.slots[i],
+                })
+            }
+            None => {
+                self.exhaustions = self.exhaustions.saturating_add(1);
+                None
+            }
+        }
+    }
+
+    /// Occupancy, for a caller that wants to react before exhaustion.
+    pub fn stats(&self) -> PoolStats {
+        PoolStats {
+            capacity: self.slots.len(),
+            available: self
+                .slots
+                .iter()
+                .filter(|s| Arc::strong_count(s) == 1 && Arc::weak_count(s) == 0)
+                .count(),
+            stuck: self
+                .busy_streak
+                .iter()
+                .filter(|&&n| n >= STUCK_AFTER)
+                .count(),
+            exhaustions: self.exhaustions,
+        }
+    }
+
+    /// The number of slots the pool was built with.
+    pub fn capacity(&self) -> usize {
+        self.slots.len()
+    }
+}
+
+impl<T> std::ops::Deref for Pooled<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &**self.slot
+    }
+}
+
+impl<T> std::ops::DerefMut for Pooled<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        Arc::get_mut(self.slot)
+            .expect("acquire established sole ownership and the borrow preserves it")
+    }
+}
+
+impl<T> Pooled<'_, T> {
+    /// Take the `Arc` for publishing.
+    ///
+    /// This is the moment the slot becomes busy: the refcount goes from one to
+    /// two, and `acquire` skips it until every receiver has dropped its
+    /// reference. Keeping that at the call site — rather than inside a
+    /// `publish` method — is deliberate, so a reader can see where capacity is
+    /// consumed.
+    ///
+    /// The pool does not care what happens next: `publish_shared`,
+    /// `publish_owned`, or a channel to another thread. It is an `Arc<T>`.
+    pub fn into_shared(self) -> Arc<T> {
+        Arc::clone(&*self.slot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default, Debug)]
+    struct Msg {
+        stamp: u64,
+    }
+
+    #[test]
+    fn a_slot_is_reused_rather_than_reallocated() {
+        let mut pool = PayloadPool::new(2, Msg::default);
+        let addr = {
+            let held = pool.acquire().expect("fresh pool").into_shared();
+            Arc::as_ptr(&held) as usize
+        };
+        // Round the ring back to the same slot; the first is free again.
+        let _second = pool.acquire().expect("second slot").into_shared();
+        let again = pool.acquire().expect("first slot, returned").into_shared();
+        assert_eq!(
+            Arc::as_ptr(&again) as usize,
+            addr,
+            "the slot was reallocated: this pool is not reusing anything"
+        );
+    }
+
+    #[test]
+    fn a_retained_arc_removes_a_slot_and_is_eventually_reported() {
+        let mut pool = PayloadPool::new(2, Msg::default);
+        // A "subscriber" that stores its message instead of dropping it.
+        let _retained = pool.acquire().expect("fresh pool").into_shared();
+        assert_eq!(
+            pool.stats().available,
+            1,
+            "the retained slot still counts as available"
+        );
+
+        for _ in 0..(STUCK_AFTER + 2) {
+            drop(pool.acquire().map(|m| m.into_shared()));
+        }
+        assert_eq!(
+            pool.stats().stuck,
+            1,
+            "a permanently held slot was never reported as stuck"
+        );
+    }
+
+    #[test]
+    fn exhaustion_returns_none_and_never_allocates() {
+        let mut pool = PayloadPool::new(2, Msg::default);
+        let _a = pool.acquire().expect("slot 0").into_shared();
+        let _b = pool.acquire().expect("slot 1").into_shared();
+        assert!(
+            pool.acquire().is_none(),
+            "the pool handed out a third slot from a capacity of two"
+        );
+        assert_eq!(pool.stats().exhaustions, 1);
+        assert_eq!(pool.stats().available, 0);
+        assert_eq!(pool.capacity(), 2, "capacity grew: acquire allocated");
+    }
+
+    #[test]
+    fn a_weak_reference_is_skipped_rather_than_panicking() {
+        // The hand-rolled version tested `strong_count == 1` and then unwrapped
+        // `Arc::get_mut`, which ALSO requires no `Weak`. A subscriber holding a
+        // Weak panicked the sender.
+        let mut pool = PayloadPool::new(1, Msg::default);
+        let shared = pool.acquire().expect("fresh pool").into_shared();
+        let weak = Arc::downgrade(&shared);
+        drop(shared);
+        assert_eq!(weak.strong_count(), 1, "only the pool's own Arc remains");
+        assert!(
+            pool.acquire().is_none(),
+            "acquire handed out a slot that still has a Weak pointing at it"
+        );
+        drop(weak);
+        assert!(
+            pool.acquire().is_some(),
+            "the slot did not return once the Weak was dropped"
+        );
+    }
+
+    #[test]
+    fn writing_through_the_guard_lands_in_the_published_arc() {
+        let mut pool = PayloadPool::new(1, Msg::default);
+        let mut m = pool.acquire().expect("fresh pool");
+        m.stamp = 4242;
+        assert_eq!(m.stamp, 4242, "Deref does not see the write");
+        let published = m.into_shared();
+        assert_eq!(published.stamp, 4242);
+    }
+
+    #[test]
+    fn a_returned_slot_becomes_acquirable_again() {
+        let mut pool = PayloadPool::new(1, Msg::default);
+        let held = pool.acquire().expect("fresh pool").into_shared();
+        assert!(pool.acquire().is_none(), "capacity one handed out two");
+        drop(held);
+        assert!(
+            pool.acquire().is_some(),
+            "a slot whose receivers all dropped was not returned to the pool"
+        );
+    }
+
+    #[test]
+    fn a_zero_capacity_pool_is_permanently_exhausted_rather_than_panicking() {
+        let mut pool = PayloadPool::new(0, Msg::default);
+        assert!(pool.acquire().is_none());
+        assert_eq!(pool.stats().exhaustions, 1);
+    }
+}

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -39,6 +39,47 @@
 //! forever. Waiting becomes meaningful only once a subscriber can hold a
 //! message across a queue, and belongs with that design rather than before it.
 //!
+//! # Where it fits in hiroz
+//!
+//! The pool holds `Arc<T>` and nothing else — no session, no keyexpr, no
+//! liveliness token — so discovery, the ROS graph and QoS negotiation neither
+//! see it nor are affected by it. What matters is only whether anything
+//! downstream *retains* a message, because a retained `Arc` is a slot out of
+//! circulation.
+//!
+//! | it works with | why |
+//! |---|---|
+//! | the wire (`publish_shared` on a plain publisher) | serialization writes a fresh `ZBuf`, so the transport queues a copy and never holds the pooled buffer |
+//! | shared memory | `serialize_to_shm` likewise copies into the SHM provider's own buffer |
+//! | `TRANSIENT_LOCAL` on a wire publisher | the durability cache keeps serialized samples, not the `Arc<T>` |
+//! | `Locality::Remote` (bus and wire together) | both routes release before `publish_shared` returns |
+//! | many subscribers | each gets a clone of the same `Arc`; fan-out costs one slot, not N |
+//! | a callback that republishes from the same pool | `into_shared` ends the pool's borrow *before* the publish, so inline delivery can re-enter it |
+//!
+//! | it does not work with | why |
+//! |---|---|
+//! | [`crate::pubsub::ZPub::publish_owned`] | takes `T` by value and gives the message away; the allocation would leave the pool for good |
+//! | `TRANSIENT_LOCAL` + `with_intra_process_only()` | refused by the publisher itself, pool or not — there is no wire to hold the history |
+//! | a subscriber that stores its `Arc` | a permanent capacity loss, reported through [`PoolStats::stuck`] |
+//! | sharing one pool across threads without a lock | `acquire` needs `&mut self`; wrap it, or give each thread its own |
+//!
+//! Two of these deserve a sentence more.
+//!
+//! **The wire is safe by copy, not by luck.** Nothing in the type system stops
+//! a future serializer from splicing the payload's existing `ZSlice` instead of
+//! writing a copy of it — and if one did, zenoh's TX queue would hold the
+//! pooled allocation while the publisher reused it. That is why the copy is
+//! pinned by a test asserting the slot comes back, rather than left as a
+//! comment.
+//!
+//! **Rewriting bytes in place is the one part that needs more than std.**
+//! `ZBuf::as_mut_slice` is behind the `pooled-payload` feature and an
+//! unreleased zenoh accessor. A pooled message whose fields are plain — a
+//! `String`, a fixed array, a `Vec` replaced wholesale — needs none of it and
+//! works against released zenoh today. Only overwriting bytes *inside* an
+//! existing `ZBuf` does, and that accessor refuses when anything else still
+//! references the buffer, which is a second guard behind the `Arc` check here.
+//!
 //! # The failure mode to watch
 //!
 //! A subscriber that *stores* its `Arc` — rather than reading it and letting it
@@ -208,8 +249,13 @@ impl<T> Pooled<'_, T> {
     /// `publish` method — is deliberate, so a reader can see where capacity is
     /// consumed.
     ///
-    /// The pool does not care what happens next: `publish_shared`,
-    /// `publish_owned`, or a channel to another thread. It is an `Arc<T>`.
+    /// The result is a plain `Arc<T>`, so it suits anything that takes one:
+    /// `ZPub::publish_shared`, a channel, another thread.
+    ///
+    /// **Not `ZPub::publish_owned`.** That takes `T` by value and hands a sole
+    /// receiver the message to own and mutate, which is the opposite of
+    /// pooling — the allocation would leave the pool and never come back.
+    /// Pooling and giving away are alternatives, not a sequence.
     pub fn into_shared(self) -> Arc<T> {
         Arc::clone(self.slot)
     }

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -128,6 +128,12 @@ pub struct PoolStats {
     pub available: usize,
     /// Slots unavailable for [`STUCK_AFTER`] consecutive acquires — almost
     /// always a subscriber that stored its `Arc`.
+    ///
+    /// This can over-report by a slot that has since been released but not yet
+    /// reacquired: the scan stops at the first free slot, so a later one keeps
+    /// its streak until the cursor reaches it. It corrects itself within one
+    /// rotation. Counting exactly would mean sweeping every slot on every
+    /// acquire, which is the cost this pool exists to avoid.
     pub stuck: usize,
     /// Times `acquire` found nothing free.
     pub exhaustions: u64,

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -188,7 +188,7 @@ impl<T> PayloadPool<T> {
 impl<T> std::ops::Deref for Pooled<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        &**self.slot
+        self.slot
     }
 }
 
@@ -211,7 +211,7 @@ impl<T> Pooled<'_, T> {
     /// The pool does not care what happens next: `publish_shared`,
     /// `publish_owned`, or a channel to another thread. It is an `Arc<T>`.
     pub fn into_shared(self) -> Arc<T> {
-        Arc::clone(&*self.slot)
+        Arc::clone(self.slot)
     }
 }
 

--- a/crates/hiroz/src/prelude.rs
+++ b/crates/hiroz/src/prelude.rs
@@ -25,6 +25,9 @@ pub use crate::context::{ZContext, ZContextBuilder};
 pub use crate::node::ZNode;
 pub use crate::local_bus::{Delivery, Published};
 pub use crate::pubsub::{ZPub, ZSub};
+
+/// Reusable message allocations for the intra-process path.
+pub use crate::payload_pool::{PayloadPool, PoolStats, Pooled};
 pub use crate::service::{RequestId, ServiceReply, ServiceRequest, ZClient, ZServer};
 
 pub use crate::action::server::{Accepted, Executing, Requested};


### PR DESCRIPTION
Closes the payload-pool design issue. Part of the intra-process meta issue.

> [!NOTE]
> **Stacked on #340**, which adds the intra-process bus this pool feeds. The base is `feat/publisher-locality`, so the diff here is the pool alone. #340 merges first.

`PayloadPool` gives hiroz the largest measured win on the intra-process branch, as a feature rather than as a pattern a user must reimplement.

```rust
let mut pool = PayloadPool::new(16, ByteMultiArray::default);
let Some(mut msg) = pool.acquire() else { return Ok(()) };  // never allocates
msg.stamp = now;                                            // written in place
publisher.publish_shared(msg.into_shared())?;
```

## What this adds

It was thirty lines of benchmark code over one feature-gated accessor. It is now `crates/hiroz/src/payload_pool.rs`, and the benchmark's hand-rolled ring is deleted rather than bypassed.

```rust
let mut pool = PayloadPool::new(16, ByteMultiArray::default);
let Some(mut msg) = pool.acquire() else { return Ok(()) };  // never allocates
msg.stamp = now;                                            // written in place
publisher.publish_shared(msg.into_shared())?;
```

**The module names no zenoh type**, so it builds against released zenoh. Only rewriting a `ZBuf`'s bytes in place still needs the unreleased accessor — and that no longer involves hiroz at all: #340 removes the wrapper, and a caller reaches zenoh's `opt_mut_slice` through `ZBuf`'s inner type with its own `[patch]`.

| property | how |
|---|---|
| `acquire` never allocates | returns `None`; an invisible fallback is the defect it exists to prevent |
| a `Weak` cannot panic the sender | `Arc::get_mut` **is** the test, not `strong_count` then `expect` |
| a retained `Arc` is visible | `PoolStats::stuck`, warned once per slot rather than per send |
| no blocking acquire | delivery is inline, so the party freeing a slot is often the caller |

7 unit tests plus 5 compatibility tests. Every defect it prevents has a detector proven to fail without it, each compiling — a revert that does not build is indistinguishable from a firing detector otherwise:

| revert | test that failed |
|---|---|
| `strong_count` + `expect` | `a_weak_reference_is_skipped_rather_than_panicking` |
| no stuck accounting | `a_retained_arc_removes_a_slot_and_is_eventually_reported` |
| silent allocating fallback | `exhaustion_returns_none_and_never_allocates` (+2) |
| a fresh allocation per acquire | `a_slot_is_reused_rather_than_reallocated` |

### It composes with the rest of hiroz

`payload_pool.rs` carries **7 unit tests** for the ring itself — acquisition, reuse, exhaustion, the stuck-slot report. `payload_pool_compat.rs` adds **5** for how it composes with publishers, QoS and fan-out, all green. Each concludes "nothing downstream retained the buffer" from `available` returning to capacity — and that is not vacuous: retaining the published `Arc` reds the wire test and only the wire test.

| works with | why |
|---|---|
| the wire, and SHM | serialization writes a **fresh** `ZBuf`, so the transport queues a copy |
| `TRANSIENT_LOCAL` | the durability cache holds serialized samples, not the `Arc<T>` |
| `Locality::Remote` | bus and wire both release before `publish_shared` returns |
| many subscribers | one `Arc` shared — fan-out costs one slot, not N |
| a callback republishing from the same pool | `into_shared` consumes the guard, ending the borrow before the publish |

**Not `publish_owned`**, which takes `T` by value and gives the message away — the opposite of pooling. (#342 renames it `publish_moved`.)

### How this differs from the pool rmw_zenoh_cpp already has

`rmw_zenoh_cpp::BufferPool` (`detail/zenoh_utils.hpp`) pools the **buffer that serialization writes into** — the CDR destination, recycled with a deleter, mutex-guarded, capped at 8 MiB to stay cache-resident, used when SHM is unavailable.

| | `rmw_zenoh_cpp::BufferPool` | the pool measured here |
|---|---|---|
| pools | the buffer serialization writes into | the user message itself |
| removes | one allocation of the CDR output | the allocation **and the serialization** |
| layer | inside the rmw, invisible to the user | above the middleware |
| exhaustion | falls back to the allocator silently | the caller decides |

They are complementary rather than competing: one makes serializing cheaper, the other avoids serializing.

**rmw_zenoh has no intra-process path of its own.** The only mentions in its source set `message_info->from_intra_process = false`. rclcpp's intra-process comms sit above the rmw and bypass it — which is what the benchmark shows: `rclcpp_ipc` 13.0 &micro;s against 26.1 &micro;s for the same binary with the middleware back in the path.

## Does this need a patched zenoh?

**The pool does not.** The module names no zenoh type; `Arc::get_mut` is std. Its seven unit tests pass with **no features enabled**.

Only rewriting the bytes inside an existing `ZBuf` does, and that is a `zenoh-buffers` patch the caller supplies, not a hiroz feature. So a pooled message whose fields are plain — a `String`, a fixed array, a `Vec` replaced wholesale — works against released zenoh today.

Measured both ways, on a pinned host, median of three interleaved runs:

| 200 Hz | plain `Vec<u8>`, **no patch** | `ZBuf`, with patch |
|---|---|---|
| 128 KiB | −94.6% | −93.7% |
| 1 MiB | −99.0% | −99.1% |

The same win either way, so the patch is not what produces it. Control (an unchanged binary in the same sweep) moved 0.7–3.1%.

> [!WARNING]
> **At 64 B pooling is a small loss**, not a win: +17.3% p50 and +8.5% min, above the control. Pooling is for large payloads. The two pooled arms above must not be compared against *each other* — they differ in message type, container and write path at once, so the difference between them is unattributable.

## Breaking changes

| change | who is affected | before → after |
|---|---|---|
| `pooled-payload` feature **removed** (in #340) | workspaces enabling it | drop the feature; patch `zenoh-buffers` and call `opt_mut_slice` on `ZBuf`'s inner type |

Nothing else. `PayloadPool` is additive, and no hiroz code path calls the gated accessor.

## What fails without this

Nothing. **No failing baseline: this adds a capability.** The justification is the caller it serves — a publisher that reuses one buffer instead of allocating per send — and the −99% that reuse is worth at 1 MiB.

## Evidence

Sweep F — the first sweep whose pooled arm publishes through `PayloadPool` rather than the benchmark's own ring. 70 cells, 3 interleaved runs, **0 failures, 0 fallbacks**; controls drifted 0.9% median over 21 unchanged cells.

| 200 Hz | `hiroz(zc)` | `hiroz(zc,pool)` | change |
|---|---|---|---|
| 64 B | 0.404 | 0.405 | +0.2% |
| 128 KiB | 8.162 | 0.454 | **−94.4%** |
| 1 MiB | 54.102 | 0.424 | **−99.2%** |

**The public API is measurably slower than the private ring it replaces**: `min` rose 17–25% across all three payloads (0.234 → 0.288 µs), consistent in sign and size and well outside control drift. That is a real regression, stated rather than omitted. It buys the `Weak` safety, the visible exhaustion and the stuck reporting above. The likely mechanism — `Arc::get_mut` reads the weak count too, and the pool keeps three parallel vectors where the ring kept one — is a hypothesis, not a measurement.

Seven unit tests plus five compatibility tests. Every defect the pool prevents has a detector proven to fail without it, and **every reverted build reported zero compile errors** — `cargo` exits 101 for a build failure and a test failure alike, so a revert that never compiled looks exactly like a detector that fired.



