### PR TITLE
refactor(pubsub)!: one publish name, with ownership choosing the route

### DIFF
--- a/crates/hiroz-tests/tests/intra_process.rs
+++ b/crates/hiroz-tests/tests/intra_process.rs
@@ -546,7 +546,7 @@ fn a_sole_receiver_is_given_the_message_to_own() -> hiroz::Result<()> {
         .with_intra_process_only()
         .build()?;
 
-    let took = publisher.publish_owned(RosString {
+    let took = publisher.publish_moved(RosString {
         data: "mine".to_owned(),
     })?;
     assert_eq!(
@@ -844,7 +844,7 @@ fn every_shared_subscriber_receives_the_same_allocation() -> hiroz::Result<()> {
 }
 
 /// #133 reached through the sibling method. `publish_shared` refuses a
-/// transient-local intra-process-only publisher; `publish_owned` took the bus
+/// transient-local intra-process-only publisher; `publish_moved` took the bus
 /// around that check and returned `Ok(1)`.
 #[test]
 fn transient_local_plus_intra_process_only_is_refused_for_owned_too() -> hiroz::Result<()> {
@@ -870,12 +870,12 @@ fn transient_local_plus_intra_process_only_is_refused_for_owned_too() -> hiroz::
         .build()?;
     wait_for_ready(Duration::from_millis(500));
 
-    let result = publisher.publish_owned(RosString {
+    let result = publisher.publish_moved(RosString {
         data: "durable, allegedly".to_owned(),
     });
     assert!(
         result.is_err(),
-        "publish_owned served the bus for a transient-local publisher"
+        "publish_moved served the bus for a transient-local publisher"
     );
     thread::sleep(Duration::from_millis(200));
     assert_eq!(
@@ -1002,9 +1002,9 @@ fn a_panicking_sole_subscriber_does_not_reach_the_publisher() -> hiroz::Result<(
     Ok(())
 }
 
-/// B1. `publish_owned` on a `Locality::Remote` publisher must reach the wire.
+/// B1. `publish_moved` on a `Locality::Remote` publisher must reach the wire.
 ///
-/// This is the detector that did not exist. Every other `publish_owned` test
+/// This is the detector that did not exist. Every other `publish_moved` test
 /// uses `with_intra_process_only()`, so none of them could see that the Remote
 /// arm took the bus and returned — losing the message to every off-session
 /// subscriber, silently, while `publish_shared` in the identical configuration
@@ -1012,7 +1012,7 @@ fn a_panicking_sole_subscriber_does_not_reach_the_publisher() -> hiroz::Result<(
 ///
 /// The far assertion is the point. The near one passes against the defect.
 #[test]
-fn publish_owned_on_a_remote_publisher_still_reaches_the_wire() -> hiroz::Result<()> {
+fn publish_moved_on_a_remote_publisher_still_reaches_the_wire() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx_tx = create_hiroz_context_with_router(&router)?;
     let ctx_far = create_hiroz_context_with_router(&router)?;
@@ -1041,7 +1041,7 @@ fn publish_owned_on_a_remote_publisher_still_reaches_the_wire() -> hiroz::Result
         .build()?;
     wait_for_ready(Duration::from_millis(800));
 
-    let outcome = publisher.publish_owned(RosString {
+    let outcome = publisher.publish_moved(RosString {
         data: "must reach both".to_owned(),
     })?;
 
@@ -1089,7 +1089,7 @@ fn transient_local_plus_remote_locality_is_allowed_on_the_owned_path() -> hiroz:
     // Permitted, because the wire runs and fills the cache. The companion test
     // above is what proves the wire actually runs; without it this assertion
     // would be satisfied by a publisher that silently dropped the message.
-    let outcome = publisher.publish_owned(RosString {
+    let outcome = publisher.publish_moved(RosString {
         data: "durable".to_owned(),
     })?;
     assert!(
@@ -1190,11 +1190,11 @@ fn a_depth_refusal_is_reported_as_dropped_not_delivered() -> hiroz::Result<()> {
     let pubr = Arc::new(pubr);
     let p2 = pubr.clone();
     publisher
-        .set(Box::new(move |m: RosString| p2.publish_owned(m)))
+        .set(Box::new(move |m: RosString| p2.publish_moved(m)))
         .map_err(|_| "publisher already set")
         .expect("set once");
 
-    pubr.publish_owned(RosString {
+    pubr.publish_moved(RosString {
         data: "recurse".to_owned(),
     })?;
 
@@ -1218,7 +1218,7 @@ fn a_depth_refusal_is_reported_as_dropped_not_delivered() -> hiroz::Result<()> {
     Ok(())
 }
 
-/// S9. `publish_shared` and `publish_owned` must agree about where a message
+/// S9. `publish_shared` and `publish_moved` must agree about where a message
 /// goes. They cannot, unless they read the same decision.
 ///
 /// They did not. Each tested the conditions itself, in the opposite order, so a
@@ -1242,7 +1242,7 @@ fn both_publish_methods_agree_when_the_assertions_conflict() -> hiroz::Result<()
     let shared = publisher.publish_shared(Arc::new(RosString {
         data: "shared".to_owned(),
     }))?;
-    let moved = publisher.publish_owned(RosString {
+    let moved = publisher.publish_moved(RosString {
         data: "moved".to_owned(),
     })?;
 
@@ -1256,7 +1256,7 @@ fn both_publish_methods_agree_when_the_assertions_conflict() -> hiroz::Result<()
     assert_eq!(
         moved,
         Published::Bus(Delivery::NoTaker),
-        "publish_owned disagreed with publish_shared"
+        "publish_moved disagreed with publish_shared"
     );
     Ok(())
 }
@@ -1310,11 +1310,11 @@ fn publish_shared_refuses_when_only_owned_subscribers_are_listening() -> hiroz::
     Ok(())
 }
 
-/// The same starvation reached through `publish_owned`, which is the likelier
+/// The same starvation reached through `publish_moved`, which is the likelier
 /// route to it: two owning subscribers means nothing can be given away, so it
 /// falls back to sharing — into the case above.
 #[test]
-fn publish_owned_refuses_when_two_owned_subscribers_cannot_be_served() -> hiroz::Result<()> {
+fn publish_moved_refuses_when_two_owned_subscribers_cannot_be_served() -> hiroz::Result<()> {
     let router = TestRouter::new();
     let ctx = create_hiroz_context_with_router(&router)?;
     let node = ctx.create_node("owned_two").build()?;
@@ -1339,7 +1339,7 @@ fn publish_owned_refuses_when_two_owned_subscribers_cannot_be_served() -> hiroz:
         .build()?;
     wait_for_ready(Duration::from_millis(300));
 
-    let outcome = publisher.publish_owned(RosString {
+    let outcome = publisher.publish_moved(RosString {
         data: "two takers, nothing to give".to_owned(),
     });
 

--- a/crates/hiroz-tests/tests/intra_process.rs
+++ b/crates/hiroz-tests/tests/intra_process.rs
@@ -147,7 +147,9 @@ fn intra_process_only_publisher_does_not_reach_another_context() -> hiroz::Resul
     });
     for _ in 0..5 {
         pub_local.publish_shared(msg.clone())?;
-        pub_control.publish(&msg)?;
+        // publish_ref, not publish(&msg): `msg` is an Arc, and a generic
+        // parameter does not deref-coerce the way `&T` did.
+        pub_control.publish_ref(&msg)?;
     }
 
     // The control must cross. Without it, a zero on `zc_local` would be

--- a/crates/hiroz-tests/tests/intra_process.rs
+++ b/crates/hiroz-tests/tests/intra_process.rs
@@ -1468,3 +1468,62 @@ fn a_channel_no_endpoint_holds_is_reclaimed() -> hiroz::Result<()> {
     drop(held);
     Ok(())
 }
+
+/// The headline of this PR is that `publish` dispatches on ownership, and until
+/// now nothing exercised it: every test called `publish_shared`/`publish_ref`
+/// directly, so the trait impls could regress without a single failure.
+///
+/// `&T` must take the wire and `Arc<T>` the bus, and both must report it.
+#[test]
+fn ownership_selects_the_route_through_the_generic_publish() -> hiroz::Result<()> {
+    let router = TestRouter::new();
+    let ctx = create_hiroz_context_with_router(&router)?;
+    let node = ctx.create_node("dispatch").build()?;
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    let h = hits.clone();
+    let _sub = node
+        .create_sub::<RosString>("dispatch_topic")
+        .build_with_shared_callback(move |_m: Arc<RosString>| {
+            h.fetch_add(1, Ordering::SeqCst);
+        })?;
+
+    let publisher = node
+        .create_pub::<RosString>("dispatch_topic")
+        .with_intra_process_only()
+        .build()?;
+    wait_for_ready(Duration::from_millis(300));
+
+    // Arc<T> -> the bus, through the trait rather than publish_shared.
+    let shared = publisher.publish(Arc::new(RosString {
+        data: "by arc".to_owned(),
+    }))?;
+    assert_eq!(
+        shared,
+        Published::Bus(Delivery::Sent(1)),
+        "an Arc argument must select the bus, got {shared:?}"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "the bus subscriber must be served"
+    );
+
+    // &T -> the wire. On an intra-process-only publisher there is no wire, so
+    // the route is observable as the *absence* of a second bus delivery.
+    let wire_pub = node.create_pub::<RosString>("dispatch_wire").build()?;
+    let borrowed = wire_pub.publish(&RosString {
+        data: "by reference".to_owned(),
+    })?;
+    assert_eq!(
+        borrowed,
+        Published::Wire,
+        "a &T argument must select the wire, got {borrowed:?}"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "the borrowed publish must not have reached the bus subscriber"
+    );
+    Ok(())
+}

--- a/crates/hiroz/src/action/server.rs
+++ b/crates/hiroz/src/action/server.rs
@@ -1043,7 +1043,8 @@ impl<A: ZAction> GoalHandle<A, Executing> {
             goal_id: self.info.goal_id,
             feedback,
         };
-        self.server.feedback_pub().publish(&msg)
+        // publish_ref: tail expression of a Result<()> function.
+        self.server.feedback_pub().publish_ref(&msg)
     }
 
     /// Check if cancellation has been requested for this goal.

--- a/crates/hiroz/src/lifecycle/node.rs
+++ b/crates/hiroz/src/lifecycle/node.rs
@@ -350,10 +350,13 @@ impl Builder for ZLifecycleNodeBuilder {
                         .lock()
                         .unwrap()
                         .trigger(t, |_| CallbackReturn::Success);
-                    // publish_ref, not publish: with `publish` generic over
-                    // Publishable, clippy's needless_borrows_for_generic_args
-                    // would have us drop the `&`, which selects the OWNED impl
-                    // and reroutes this from the wire to the intra-process bus.
+                    // publish_ref, not publish: `publish` is generic over
+                    // Publishable, so clippy's needless_borrows_for_generic_args
+                    // fires on `publish(&expr)` and suggests dropping the `&`.
+                    // There is no impl for `T`, so that suggestion no longer
+                    // compiles rather than rerouting silently — which is why the
+                    // impl was removed. Naming the wire call keeps the lint
+                    // silent and says what this line means.
                     let _ = te_cs.publish_ref(&make_transition_event(t, start, goal));
                     true
                 } else {

--- a/crates/hiroz/src/lifecycle/node.rs
+++ b/crates/hiroz/src/lifecycle/node.rs
@@ -350,7 +350,11 @@ impl Builder for ZLifecycleNodeBuilder {
                         .lock()
                         .unwrap()
                         .trigger(t, |_| CallbackReturn::Success);
-                    let _ = te_cs.publish(&make_transition_event(t, start, goal));
+                    // publish_ref, not publish: with `publish` generic over
+                    // Publishable, clippy's needless_borrows_for_generic_args
+                    // would have us drop the `&`, which selects the OWNED impl
+                    // and reroutes this from the wire to the intra-process bus.
+                    let _ = te_cs.publish_ref(&make_transition_event(t, start, goal));
                     true
                 } else {
                     warn!("change_state: invalid id={tid} label='{label}' from {current:?}");

--- a/crates/hiroz/src/lifecycle/publisher.rs
+++ b/crates/hiroz/src/lifecycle/publisher.rs
@@ -73,7 +73,8 @@ impl<T: ZMessage, S: ZSerializer> ZLifecyclePublisher<T, S> {
             }
             return Ok(());
         }
-        self.inner.publish(msg)
+        // publish_ref: tail expression of a Result<()> function.
+        self.inner.publish_ref(msg)
     }
 
     /// Returns `true` if this publisher is currently activated.

--- a/crates/hiroz/src/local_bus.rs
+++ b/crates/hiroz/src/local_bus.rs
@@ -204,10 +204,6 @@ pub struct Channel {
 /// not be conflated: a caller may fall back to the wire on `NoTaker`, but doing
 /// so on `DepthExceeded` re-enters the same callback on a zenoh thread with a
 /// fresh depth counter and loops forever.
-///
-/// `Wire` is not a bus outcome: it says the message went to zenoh, where the
-/// audience is not knowable from here. It exists so one `publish` can report
-/// what it did whichever route it took.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Delivery {
@@ -217,10 +213,7 @@ pub enum Delivery {
     NoTaker,
     /// Refused: delivery is already nested `MAX_DELIVERY_DEPTH` deep.
     DepthExceeded,
-    /// Published to zenoh. The bus was not used, so no local count exists.
-    Wire,
 }
-
 
 /// Which routes one publish took, and what the bus did on its route.
 ///

--- a/crates/hiroz/src/local_bus.rs
+++ b/crates/hiroz/src/local_bus.rs
@@ -204,7 +204,12 @@ pub struct Channel {
 /// not be conflated: a caller may fall back to the wire on `NoTaker`, but doing
 /// so on `DepthExceeded` re-enters the same callback on a zenoh thread with a
 /// fresh depth counter and loops forever.
+///
+/// `Wire` is not a bus outcome: it says the message went to zenoh, where the
+/// audience is not knowable from here. It exists so one `publish` can report
+/// what it did whichever route it took.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Delivery {
     /// Handed to this many subscribers.
     Sent(usize),
@@ -212,6 +217,8 @@ pub enum Delivery {
     NoTaker,
     /// Refused: delivery is already nested `MAX_DELIVERY_DEPTH` deep.
     DepthExceeded,
+    /// Published to zenoh. The bus was not used, so no local count exists.
+    Wire,
 }
 
 

--- a/crates/hiroz/src/local_bus.rs
+++ b/crates/hiroz/src/local_bus.rs
@@ -393,7 +393,7 @@ impl Channel {
     /// anything else is subscribed as well: with a second receiver the message
     /// cannot be given away, and silently downgrading to a shared delivery
     /// would defeat the point of having asked for ownership.
-    pub fn publish_owned<T>(&self, payload: T) -> core::result::Result<Delivery, T>
+    pub fn publish_moved<T>(&self, payload: T) -> core::result::Result<Delivery, T>
     where
         T: Any + Send + 'static,
     {
@@ -430,7 +430,7 @@ impl Channel {
 
         // Mirror the shared path: a callback that panicked delivered nothing, so
         // reporting Sent(1) would tell the caller a message landed when none did.
-        if invoke_isolated("local_bus::publish_owned", || cb(Box::new(payload))) {
+        if invoke_isolated("local_bus::publish_moved", || cb(Box::new(payload))) {
             Ok(Delivery::Sent(1))
         } else {
             Ok(Delivery::NoTaker)
@@ -600,7 +600,7 @@ pub fn subscriber_count(zid: ZenohId, topic: &str) -> usize {
 /// Register `callback` to receive messages of type `T` **by value**.
 ///
 /// It is served only when it is the sole subscriber on the channel for that
-/// type; see [`Channel::publish_owned`]. Registering one alongside a shared
+/// type; see [`Channel::publish_moved`]. Registering one alongside a shared
 /// subscriber is allowed, and simply means the owned path cannot give anything
 /// away, so the publisher falls back to the shared or wire path.
 pub fn subscribe_owned<T, F>(channel: Arc<Channel>, callback: F) -> LocalSubscription

--- a/crates/hiroz/src/local_bus.rs
+++ b/crates/hiroz/src/local_bus.rs
@@ -24,7 +24,7 @@
 //! | | here | not here |
 //! |---|---|---|
 //! | audience | every same-session subscriber registered on this channel | subscribers reached only over the wire |
-//! | type check | exact [`core::any::TypeId`] | any structural or version-tolerant match |
+//! | type check | exact [`TypeId`](core::any::TypeId) | any structural or version-tolerant match |
 //! | mutability | shared `Arc<T>`, or moved to a sole receiver | a receiver mutating a payload others still hold |
 //! | choosing the path | the caller asserts the audience | inferring it |
 //!
@@ -44,7 +44,7 @@
 //! must not see each other's traffic. Both `ZPub` and `ZSub` already hold an
 //! `Arc<Session>`, so this needs no plumbing through the node tree.
 //!
-//! A publisher takes its [`crate::local_bus::Channel`] handle when it is built and never touches
+//! A publisher takes its [`Channel`](crate::local_bus::Channel) handle when it is built and never touches
 //! the registry again. Resolving per message would mean hashing a
 //! fully-qualified ROS key expression on every publish, which at small payloads
 //! is a visible share of the whole path.

--- a/crates/hiroz/src/payload_pool.rs
+++ b/crates/hiroz/src/payload_pool.rs
@@ -58,7 +58,7 @@
 //!
 //! | it does not work with | why |
 //! |---|---|
-//! | [`crate::pubsub::ZPub::publish_owned`] | takes `T` by value and gives the message away; the allocation would leave the pool for good |
+//! | [`crate::pubsub::ZPub::publish_moved`] | takes `T` by value and gives the message away; the allocation would leave the pool for good |
 //! | `TRANSIENT_LOCAL` + `with_intra_process_only()` | refused by the publisher itself, pool or not — there is no wire to hold the history |
 //! | a subscriber that stores its `Arc` | a permanent capacity loss, reported through [`PoolStats::stuck`](crate::payload_pool::PoolStats::stuck) |
 //! | sharing one pool across threads without a lock | `acquire` needs `&mut self`; wrap it, or give each thread its own |
@@ -260,7 +260,7 @@ impl<T> Pooled<'_, T> {
     /// The result is a plain `Arc<T>`, so it suits anything that takes one:
     /// `ZPub::publish_shared`, a channel, another thread.
     ///
-    /// **Not `ZPub::publish_owned`.** That takes `T` by value and hands a sole
+    /// **Not `ZPub::publish_moved`.** That takes `T` by value and hands a sole
     /// receiver the message to own and mutate, which is the opposite of
     /// pooling — the allocation would leave the pool and never come back.
     /// Pooling and giving away are alternatives, not a sequence.

--- a/crates/hiroz/src/prelude.rs
+++ b/crates/hiroz/src/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::Builder;
 pub use crate::context::{ZContext, ZContextBuilder};
 pub use crate::node::ZNode;
 pub use crate::local_bus::{Delivery, Published};
-pub use crate::pubsub::{ZPub, ZSub};
+pub use crate::pubsub::{Publishable, ZPub, ZSub};
 
 /// Reusable message allocations for the intra-process path.
 pub use crate::payload_pool::{PayloadPool, PoolStats, Pooled};

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -936,7 +936,7 @@ where
                 "publish on a TRANSIENT_LOCAL, intra-process-only publisher for {}: \
                  the intra-process path has no durability cache, so a late-joining \
                  subscriber would be served a history this message is missing from. \
-                 Use publish(), or drop the transient-local durability.",
+                 Use publish_ref(), or drop the transient-local durability.",
                 self.entity.topic
             )
             .into(),

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -638,10 +638,6 @@ where
         Attachment::with_clock(sn as _, self.gid, &self.clock)
     }
 
-    /// Serialize and publish `msg` on the topic. Blocks until the put completes.
-    ///
-    /// Use [`async_publish`](ZPub::async_publish) when calling from async code to
-    /// avoid blocking the executor.
     /// Publish, with the argument's ownership choosing the route.
     ///
     /// This is the one publish name, in the shape rclcpp uses: there,
@@ -665,6 +661,19 @@ where
     ///
     /// The named methods remain, and stay the right choice when you want their
     /// exact return type.
+    ///
+    /// # Blocking, and which route it applies to
+    ///
+    /// The two routes block differently, so one blanket statement would be
+    /// wrong for one of them:
+    ///
+    /// - **the wire** blocks until the put completes. Reach for
+    ///   [`async_publish`](ZPub::async_publish) from async code to avoid
+    ///   holding the executor.
+    /// - **the bus** does not serialize and never touches zenoh, but delivery
+    ///   is *synchronous and inline*: every subscriber callback has run before
+    ///   this returns. It is not the blocking `async_publish` avoids, and
+    ///   `async_publish` is wire-only — it cannot be used to escape it.
     pub fn publish(&self, msg: impl Publishable<T, S>) -> Result<Published> {
         msg.publish_to(self)
     }

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -167,9 +167,9 @@ impl<T: ZMessage, S: ZSerializer> std::fmt::Debug for ZPub<T, S> {
 /// Implemented for `&T`, `Arc<T>` and `T`. The three impls cannot overlap: the
 /// trait carries the message type, so `Publishable<U> for &U` and
 /// `Publishable<&U> for &U` are different trait references.
-pub trait Publishable<T: ZMessage, S>: Sized {
+pub trait Publishable<T: ZMessage, S: ZSerializer>: Sized {
     /// Publish `self` through `publisher`, by the route its ownership selects.
-    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery>;
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published>;
 }
 
 impl<T, S> Publishable<T, S> for &T
@@ -177,9 +177,9 @@ where
     T: ZMessage + 'static,
     S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
-    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
         publisher.publish_ref(self)?;
-        Ok(Delivery::Wire)
+        Ok(Published::Wire)
     }
 }
 
@@ -188,9 +188,20 @@ where
     T: ZMessage + Send + Sync + 'static,
     S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
-    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
+        // publish_shared returns 0 both when the bus had no taker and when the
+        // caller asserted nothing and it went to the wire. The publisher knows
+        // which, so ask it rather than guessing from the count.
         let n = publisher.publish_shared(self)?;
-        Ok(if n == 0 { Delivery::Wire } else { Delivery::Sent(n) })
+        Ok(if publisher.takes_the_bus() {
+            Published::Bus(if n == 0 {
+                Delivery::NoTaker
+            } else {
+                Delivery::Sent(n)
+            })
+        } else {
+            Published::Wire
+        })
     }
 }
 
@@ -199,9 +210,17 @@ where
     T: ZMessage + Send + Sync + 'static,
     S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
-    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
         let n = publisher.publish_owned(self)?;
-        Ok(if n == 0 { Delivery::Wire } else { Delivery::Sent(n) })
+        Ok(if publisher.takes_the_bus() {
+            Published::Bus(if n == 0 {
+                Delivery::NoTaker
+            } else {
+                Delivery::Sent(n)
+            })
+        } else {
+            Published::Wire
+        })
     }
 }
 
@@ -657,7 +676,7 @@ where
     ///
     /// The named methods remain, and stay the right choice when you want their
     /// exact return type rather than [`Delivery`].
-    pub fn publish(&self, msg: impl Publishable<T, S>) -> Result<Delivery> {
+    pub fn publish(&self, msg: impl Publishable<T, S>) -> Result<Published> {
         msg.publish_to(self)
     }
 
@@ -666,6 +685,14 @@ where
     /// [`ZPub::publish`] reaches this for a `&T` argument. Call it directly when
     /// you want the wire whatever else is configured, or when you want the
     /// `Result<()>` shape rather than [`Delivery`].
+    /// Whether a bus route is available: the caller asserted the audience.
+    ///
+    /// Mirrors the condition `publish_shared` and `publish_owned` use, so
+    /// [`Published`] can say which route ran without inferring it from a count.
+    pub(crate) fn takes_the_bus(&self) -> bool {
+        self.intra_process_only || self.locality == Some(zenoh::sample::Locality::Remote)
+    }
+
     pub fn publish_ref(&self, msg: &T) -> Result<()> {
         use zenoh_buffers::buffer::Buffer;
 

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -167,15 +167,15 @@ impl<T: ZMessage, S: ZSerializer> std::fmt::Debug for ZPub<T, S> {
 /// Implemented for `&T`, `Arc<T>` and `T`. The three impls cannot overlap: the
 /// trait carries the message type, so `Publishable<U> for &U` and
 /// `Publishable<&U> for &U` are different trait references.
-pub trait Publishable<T: ZMessage, S: ZSerializer>: Sized {
+pub trait Publishable<T: ZMessage, S>: Sized {
     /// Publish `self` through `publisher`, by the route its ownership selects.
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery>;
 }
 
 impl<T, S> Publishable<T, S> for &T
 where
-    T: ZMessage,
-    S: ZSerializer<Input<'static> = &'static T>,
+    T: ZMessage + 'static,
+    S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
         publisher.publish_ref(self)?;
@@ -186,7 +186,7 @@ where
 impl<T, S> Publishable<T, S> for Arc<T>
 where
     T: ZMessage + Send + Sync + 'static,
-    S: ZSerializer<Input<'static> = &'static T>,
+    S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
         let n = publisher.publish_shared(self)?;
@@ -197,7 +197,7 @@ where
 impl<T, S> Publishable<T, S> for T
 where
     T: ZMessage + Send + Sync + 'static,
-    S: ZSerializer<Input<'static> = &'static T>,
+    S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
         let n = publisher.publish_owned(self)?;

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -211,7 +211,7 @@ where
     S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
-        let n = publisher.publish_owned(self)?;
+        let n = publisher.publish_moved(self)?;
         Ok(if publisher.takes_the_bus() {
             Published::Bus(if n == 0 {
                 Delivery::NoTaker
@@ -666,7 +666,7 @@ where
     /// |---|---|---|
     /// | `&T` | zenoh | [`ZPub::publish_ref`] |
     /// | `Arc<T>` | the bus, every subscriber sharing one allocation | [`ZPub::publish_shared`] |
-    /// | `T` | the bus, a sole receiver owning it | [`ZPub::publish_owned`] |
+    /// | `T` | the bus, a sole receiver owning it | [`ZPub::publish_moved`] |
     ///
     /// **The routing rules are unchanged.** A bus route still requires the
     /// caller to have asserted the audience with
@@ -687,7 +687,7 @@ where
     /// `Result<()>` shape rather than [`Delivery`].
     /// Whether a bus route is available: the caller asserted the audience.
     ///
-    /// Mirrors the condition `publish_shared` and `publish_owned` use, so
+    /// Mirrors the condition `publish_shared` and `publish_moved` use, so
     /// [`Published`] can say which route ran without inferring it from a count.
     pub(crate) fn takes_the_bus(&self) -> bool {
         self.intra_process_only || self.locality == Some(zenoh::sample::Locality::Remote)
@@ -873,7 +873,7 @@ where
                             "publish_shared on an intra-process-only publisher for {}: \
                              {owned} subscriber(s) on this topic take the message by value, \
                              and a shared publish cannot serve them. The message would be \
-                             dropped with no wire behind it. Use publish_owned(), or build \
+                             dropped with no wire behind it. Use publish_moved(), or build \
                              the subscriber with build_with_shared_callback().",
                             self.entity.topic
                         )
@@ -892,7 +892,7 @@ where
             // Both audiences, and no subscriber is on both. TRANSIENT_LOCAL is
             // safe here: the wire publish populates the cache as it always did.
             Route::BusAndWire => {
-                // Wire first, matching publish_owned. Bus delivery is
+                // Wire first, matching publish_moved. Bus delivery is
                 // synchronous, so running it first and then failing on the wire
                 // returns Err *after* every local subscriber has already been
                 // called — and Result<Published> has no partial-success value
@@ -911,7 +911,7 @@ where
     ///
     /// Resolved in one place because it is asserted by the caller and read by
     /// every publishing method. When each method decided for itself they drifted:
-    /// `publish_owned` on a `Locality::Remote` publisher took the bus and
+    /// `publish_moved` on a `Locality::Remote` publisher took the bus and
     /// returned, losing the message for every off-session subscriber, while
     /// `publish_shared` in the identical configuration served both.
     ///
@@ -933,7 +933,7 @@ where
     ///
     /// This lives in one place because it must guard **every** route onto the
     /// bus. It was originally written inline in `publish_shared`, and
-    /// `publish_owned` reached the bus around it — the same violation, through
+    /// `publish_moved` reached the bus around it — the same violation, through
     /// the sibling method. See #133.
     fn refuse_durable_bus(&self) -> Option<zenoh::Error> {
         if !self.intra_process_only {
@@ -972,8 +972,7 @@ where
     /// `intra_process_only` publisher with no listener reports
     /// `Bus(Delivery::NoTaker)` and the message is dropped; it does **not**
     /// fall through to the wire, because such a publisher has none.
-    ///
-    pub fn publish_owned(&self, msg: T) -> Result<Published>
+    pub fn publish_moved(&self, msg: T) -> Result<Published>
     where
         T: Send + Sync + 'static,
     {
@@ -986,7 +985,7 @@ where
             Route::BusAndWire => {
                 self.publish_ref(&msg)?;
                 Ok(Published::BusAndWire(
-                    match self.local_channel.publish_owned(msg) {
+                    match self.local_channel.publish_moved(msg) {
                         Ok(d) => d,
                         // No sole owning receiver; the shared half may want it.
                         Err(returned) => self.local_channel.publish(Arc::new(returned)),
@@ -997,7 +996,7 @@ where
                 if let Some(e) = self.refuse_durable_bus() {
                     return Err(e);
                 }
-                match self.local_channel.publish_owned(msg) {
+                match self.local_channel.publish_moved(msg) {
                     Ok(d) => Ok(Published::Bus(d)),
                     // Handed back untouched: not exactly one owning receiver.
                     // Share it instead — publish_shared refuses rather than
@@ -1324,7 +1323,7 @@ where
 
     /// Build a subscriber whose callback receives the message **by value**.
     ///
-    /// Served only by [`ZPub::publish_owned`], and only when this is the sole
+    /// Served only by [`ZPub::publish_moved`], and only when this is the sole
     /// subscriber on the topic for this type — with a second receiver the
     /// message cannot be given away. Otherwise the publisher falls back to a
     /// shared or wire delivery, which this subscriber does not receive.
@@ -1340,7 +1339,7 @@ where
         let zid = self.session.zid();
         // Both halves run the same callback. The wire half is not decoration:
         // without it this subscriber discards every message that does not
-        // arrive by `publish_owned` on the bus — including from every remote
+        // arrive by `publish_moved` on the bus — including from every remote
         // publisher — while still advertising a live subscription.
         //
         // It cannot deliver twice: a publisher takes the bus or the wire for

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -161,6 +161,50 @@ impl<T: ZMessage, S: ZSerializer> std::fmt::Debug for ZPub<T, S> {
     }
 }
 
+
+/// What may be handed to [`ZPub::publish`], and where each form goes.
+///
+/// Implemented for `&T`, `Arc<T>` and `T`. The three impls cannot overlap: the
+/// trait carries the message type, so `Publishable<U> for &U` and
+/// `Publishable<&U> for &U` are different trait references.
+pub trait Publishable<T: ZMessage, S: ZSerializer>: Sized {
+    /// Publish `self` through `publisher`, by the route its ownership selects.
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery>;
+}
+
+impl<T, S> Publishable<T, S> for &T
+where
+    T: ZMessage,
+    S: ZSerializer<Input<'static> = &'static T>,
+{
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+        publisher.publish_ref(self)?;
+        Ok(Delivery::Wire)
+    }
+}
+
+impl<T, S> Publishable<T, S> for Arc<T>
+where
+    T: ZMessage + Send + Sync + 'static,
+    S: ZSerializer<Input<'static> = &'static T>,
+{
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+        let n = publisher.publish_shared(self)?;
+        Ok(if n == 0 { Delivery::Wire } else { Delivery::Sent(n) })
+    }
+}
+
+impl<T, S> Publishable<T, S> for T
+where
+    T: ZMessage + Send + Sync + 'static,
+    S: ZSerializer<Input<'static> = &'static T>,
+{
+    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Delivery> {
+        let n = publisher.publish_owned(self)?;
+        Ok(if n == 0 { Delivery::Wire } else { Delivery::Sent(n) })
+    }
+}
+
 #[derive(Debug)]
 pub struct ZPubBuilder<T, S = SerdeCdrSerdes<T>> {
     pub(crate) entity: EndpointEntity,
@@ -593,7 +637,36 @@ where
         payload_len = tracing::field::Empty,
         used_shm = tracing::field::Empty
     ))]
-    pub fn publish(&self, msg: &T) -> Result<()> {
+    /// Publish, with the argument's ownership choosing the route.
+    ///
+    /// This is the one publish name, in the shape rclcpp uses: there,
+    /// `publish(const&)` copies and `publish(unique_ptr)` moves, and the
+    /// overload picks the path. Rust has no overloading, so a trait carries it.
+    ///
+    /// | argument | route | equivalent to |
+    /// |---|---|---|
+    /// | `&T` | zenoh | [`ZPub::publish_ref`] |
+    /// | `Arc<T>` | the bus, every subscriber sharing one allocation | [`ZPub::publish_shared`] |
+    /// | `T` | the bus, a sole receiver owning it | [`ZPub::publish_owned`] |
+    ///
+    /// **The routing rules are unchanged.** A bus route still requires the
+    /// caller to have asserted the audience with
+    /// [`ZPubBuilder::with_intra_process_only`] or a `Locality::Remote`; without
+    /// one, an `Arc<T>` goes on the wire exactly as before. This method renames
+    /// nothing about who decides.
+    ///
+    /// The named methods remain, and stay the right choice when you want their
+    /// exact return type rather than [`Delivery`].
+    pub fn publish(&self, msg: impl Publishable<T, S>) -> Result<Delivery> {
+        msg.publish_to(self)
+    }
+
+    /// Publish over zenoh, always.
+    ///
+    /// [`ZPub::publish`] reaches this for a `&T` argument. Call it directly when
+    /// you want the wire whatever else is configured, or when you want the
+    /// `Result<()>` shape rather than [`Delivery`].
+    pub fn publish_ref(&self, msg: &T) -> Result<()> {
         use zenoh_buffers::buffer::Buffer;
 
         // Try direct SHM serialization if configured
@@ -797,11 +870,11 @@ where
                 // returns Err *after* every local subscriber has already been
                 // called — and Result<Published> has no partial-success value
                 // to say so. A caller that retries then delivers twice locally.
-                self.publish(&msg)?;
+                self.publish_ref(&msg)?;
                 Ok(Published::BusAndWire(self.local_channel.publish(msg)))
             }
             Route::WireOnly => {
-                self.publish(&msg)?;
+                self.publish_ref(&msg)?;
                 Ok(Published::Wire)
             }
         }
@@ -884,7 +957,7 @@ where
             // wire but stop serving owned subscribers, because the shared path
             // filters on `is_shared()`.
             Route::BusAndWire => {
-                self.publish(&msg)?;
+                self.publish_ref(&msg)?;
                 Ok(Published::BusAndWire(
                     match self.local_channel.publish_owned(msg) {
                         Ok(d) => d,
@@ -906,7 +979,7 @@ where
                 }
             }
             Route::WireOnly => {
-                self.publish(&msg)?;
+                self.publish_ref(&msg)?;
                 Ok(Published::Wire)
             }
         }

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -207,19 +207,11 @@ where
     S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
 {
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
-        // publish_shared returns 0 both when the bus had no taker and when the
-        // caller asserted nothing and it went to the wire. The publisher knows
-        // which, so ask it rather than guessing from the count.
-        let n = publisher.publish_shared(self)?;
-        Ok(if publisher.takes_the_bus() {
-            Published::Bus(if n == 0 {
-                Delivery::NoTaker
-            } else {
-                Delivery::Sent(n)
-            })
-        } else {
-            Published::Wire
-        })
+        // `publish_shared` reports the route itself, so there is nothing to
+        // reconstruct here. It used to return a count, which could not say
+        // whether a zero meant "the bus had no taker" or "there is no bus on
+        // this publisher".
+        publisher.publish_shared(self)
     }
 }
 
@@ -650,12 +642,6 @@ where
     ///
     /// Use [`async_publish`](ZPub::async_publish) when calling from async code to
     /// avoid blocking the executor.
-    #[tracing::instrument(name = "publish", skip(self, msg), fields(
-        topic = %self.entity.topic,
-        sn = self.sn.load(Ordering::Acquire),
-        payload_len = tracing::field::Empty,
-        used_shm = tracing::field::Empty
-    ))]
     /// Publish, with the argument's ownership choosing the route.
     ///
     /// This is the one publish name, in the shape rclcpp uses: there,
@@ -678,7 +664,7 @@ where
     /// nothing about who decides.
     ///
     /// The named methods remain, and stay the right choice when you want their
-    /// exact return type rather than [`Delivery`].
+    /// exact return type.
     pub fn publish(&self, msg: impl Publishable<T, S>) -> Result<Published> {
         msg.publish_to(self)
     }
@@ -687,15 +673,13 @@ where
     ///
     /// [`ZPub::publish`] reaches this for a `&T` argument. Call it directly when
     /// you want the wire whatever else is configured, or when you want the
-    /// `Result<()>` shape rather than [`Delivery`].
-    /// Whether a bus route is available: the caller asserted the audience.
-    ///
-    /// Mirrors the condition `publish_shared` and `publish_moved` use, so
-    /// [`Published`] can say which route ran without inferring it from a count.
-    pub(crate) fn takes_the_bus(&self) -> bool {
-        self.intra_process_only || self.locality == Some(zenoh::sample::Locality::Remote)
-    }
-
+    /// `Result<()>` shape rather than [`Published`].
+    #[tracing::instrument(name = "publish", skip(self, msg), fields(
+        topic = %self.entity.topic,
+        sn = self.sn.load(Ordering::Acquire),
+        payload_len = tracing::field::Empty,
+        used_shm = tracing::field::Empty
+    ))]
     pub fn publish_ref(&self, msg: &T) -> Result<()> {
         use zenoh_buffers::buffer::Buffer;
 

--- a/crates/hiroz/src/pubsub.rs
+++ b/crates/hiroz/src/pubsub.rs
@@ -164,9 +164,27 @@ impl<T: ZMessage, S: ZSerializer> std::fmt::Debug for ZPub<T, S> {
 
 /// What may be handed to [`ZPub::publish`], and where each form goes.
 ///
-/// Implemented for `&T`, `Arc<T>` and `T`. The three impls cannot overlap: the
-/// trait carries the message type, so `Publishable<U> for &U` and
+/// Implemented for `&T` and `Arc<T>`. The impls cannot overlap: the trait
+/// carries the message type, so `Publishable<U> for &U` and
 /// `Publishable<&U> for &U` are different trait references.
+///
+/// # Why there is no impl for `T`
+///
+/// There was one, routing to [`ZPub::publish_moved`]. It was removed because it
+/// turned a correct lint into a silent reroute.
+///
+/// `clippy::needless_borrows_for_generic_args` fires on `publish(&expr)` when
+/// the unborrowed expression also satisfies the bound, and suggests dropping
+/// the `&`. With an impl for `T` that suggestion selects a different impl and
+/// moves the message from the wire to the intra-process bus, with no error and
+/// no failing test. This repository gates on `-D warnings`, so a contributor
+/// would be told to make that change.
+///
+/// Measured: with the impl present the lint fires twice and clippy fails; with
+/// it removed the same call site compiles and clippy passes with no errors.
+///
+/// The moved route is still available, by name, as [`ZPub::publish_moved`] —
+/// which is the clearer spelling for a call that gives the message away.
 pub trait Publishable<T: ZMessage, S: ZSerializer>: Sized {
     /// Publish `self` through `publisher`, by the route its ownership selects.
     fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published>;
@@ -205,24 +223,6 @@ where
     }
 }
 
-impl<T, S> Publishable<T, S> for T
-where
-    T: ZMessage + Send + Sync + 'static,
-    S: for<'a> ZSerializer<Input<'a> = &'a T> + 'static,
-{
-    fn publish_to(self, publisher: &ZPub<T, S>) -> Result<Published> {
-        let n = publisher.publish_moved(self)?;
-        Ok(if publisher.takes_the_bus() {
-            Published::Bus(if n == 0 {
-                Delivery::NoTaker
-            } else {
-                Delivery::Sent(n)
-            })
-        } else {
-            Published::Wire
-        })
-    }
-}
 
 #[derive(Debug)]
 pub struct ZPubBuilder<T, S = SerdeCdrSerdes<T>> {
@@ -666,7 +666,10 @@ where
     /// |---|---|---|
     /// | `&T` | zenoh | [`ZPub::publish_ref`] |
     /// | `Arc<T>` | the bus, every subscriber sharing one allocation | [`ZPub::publish_shared`] |
-    /// | `T` | the bus, a sole receiver owning it | [`ZPub::publish_moved`] |
+    ///
+    /// There is deliberately no `T` form: see [`Publishable`] for why an impl
+    /// on the bare value made a clippy suggestion reroute messages. Give a
+    /// message away with [`ZPub::publish_moved`].
     ///
     /// **The routing rules are unchanged.** A bus route still requires the
     /// caller to have asserted the audience with

--- a/crates/rmw-zenoh-rs/src/pubsub.rs
+++ b/crates/rmw-zenoh-rs/src/pubsub.rs
@@ -46,7 +46,7 @@ impl PublisherImpl {
         let ros_msg = crate::msg::RosMessage::new(msg as *const crate::c_void, self.ts);
         // publish_ref, not publish: this is the tail expression of a
         // Result<()> function on the C ABI path, and publish now returns
-        // Result<Delivery>. The rmw contract is "sent or error", with no
+        // Result<Published>. The rmw contract is "sent or error", with no
         // count to report.
         self.inner.publish_ref(&ros_msg)
     }

--- a/crates/rmw-zenoh-rs/src/pubsub.rs
+++ b/crates/rmw-zenoh-rs/src/pubsub.rs
@@ -44,7 +44,11 @@ pub struct PublisherImpl {
 impl PublisherImpl {
     pub fn publish(&self, msg: *const ::std::os::raw::c_void) -> Result<()> {
         let ros_msg = crate::msg::RosMessage::new(msg as *const crate::c_void, self.ts);
-        self.inner.publish(&ros_msg)
+        // publish_ref, not publish: this is the tail expression of a
+        // Result<()> function on the C ABI path, and publish now returns
+        // Result<Delivery>. The rmw contract is "sent or error", with no
+        // count to report.
+        self.inner.publish_ref(&ros_msg)
     }
 
     pub fn publish_serialized_message(&self, msg: &[u8]) -> Result<()> {


### PR DESCRIPTION
Closes the publish-API design issue. Part of the intra-process meta issue.

> [!NOTE]
> **Stacked on #341, which is stacked on #340.** The base is `feat/payload-pool`, so the diff here is the publish API alone.
>
> Rebased onto the hardened base. Three things the rebase removed: `Publishable for Arc<T>` had been reconstructing a `Published` from a count, `takes_the_bus()` was a **third** copy of the routing condition, and `#[instrument(name = "publish")]` — which records the wire sequence number — had been left on the generic forwarder, where a bus publish would have emitted a span whose `sn` never advanced. It now sits on `publish_ref`.

```rust
publisher.publish(&msg)?;        // zenoh          -> Published::Wire
publisher.publish(arc)?;         // shared bus     -> Published::Bus(Delivery::Sent(n))
publisher.publish_moved(msg)?;   // gives it away, by name
publisher.publish_ref(&msg)?;    // explicit wire, keeps Result<()>
```

This is rclcpp's shape — `publish(const&)` against `publish(std::move(msg))` — carried by a trait, since Rust has no overloading. **Routing rules are unchanged**: a bus route still needs the caller to assert the audience.

Three findings came out of building it, and two of them cost the design something:

| finding | outcome |
|---|---|
| the impls cannot overlap, because the trait carries the message type | confirmed by the compiler — no `E0119` |
| **a generic parameter does not deref-coerce**, so `publish(&arc)` stops compiling where `publish(&self, msg: &T)` accepted it | a loud compile error, never a silent reroute; `publish_ref` is the fix |
| **`clippy::needless_borrows_for_generic_args` suggested dropping the `&`, which selected a different impl and moved a message from the wire to the bus** | **no impl for `T`.** Measured at one call site: with the impl the lint fires twice and clippy fails; without it the call compiles and clippy passes with zero errors |

The third is why `publish` covers two routes rather than three. The moved route keeps its own name, which says what it does better than `publish(msg)` did.

`Published { Wire, Bus(Delivery), BusAndWire(Delivery) }` composes rather than widening `Delivery`: a `Wire` variant inside `Delivery` would have put a value the bus never returns into the type whose contract is that `NoTaker` and `DepthExceeded` stay distinct.

> [!NOTE]
> `Published` is **defined in #340**, not here. It moved down once the base needed to report the same three routes; this PR consumes it. The base also resolves the route in one place, so `publish` and `publish_moved` cannot disagree about where a message goes.

## Breaking changes

| change | who is affected | before → after |
|---|---|---|
| `publish` returns `Result<Published>`, not `Result<()>` | callers who **bind or match** the result. `publish(..)?;` in statement position is unaffected | `let () = pub.publish(&m)?;` → `pub.publish(&m)?;` |
| `publish` is generic, so its argument no longer deref-coerces | callers passing `&Arc<T>`, `&Box<T>` or a newtype reference | `publish(&arc)` → `publish_ref(&arc)` |
| no `Publishable` impl for `T` | callers passing an owned value | `publish(msg)` → `publish_moved(msg)` |
| `publish_owned` renamed | callers of it | `publish_owned(msg)` → `publish_moved(msg)` |

**Each of the first three is a compile error, never a silent behaviour change.**

`publish_owned` named the wrong party: read literally it describes the *publisher's* relationship to the message, which is equally true of `publish_shared`, so it distinguished nothing. The set now names the argument's fate — borrowed, shared, moved.

## Not affected

| | why |
|---|---|
| `hiroz-py` | reaches publishing through `RawPublisher` → `publish_serialized`; never touches `ZPub::publish` |
| `rmw-zenoh-rs` (the C ABI) | one call site pinned to `publish_ref`, because it is the tail expression of a `Result<()>` function. **Builds clean** — verified by compiling it, in the `default` devshell that carries `AMENT_PREFIX_PATH` |
| routing | unchanged; a bus route still needs the caller to assert the audience |
| `publish(&T)` behaviour | unchanged |

Three tail-position call sites needed pinning. A grep found one; the compiler found the other two (`action::server::publish_feedback`, `lifecycle::publisher::publish`) and a third later. For a signature change the compiler is the detector and a grep is a hypothesis.

## Evidence

Full gate at `dd3aec9f8`, in a devshell with ROS headers:

| gate | result |
|---|---|
| clippy `-D warnings` | 0 |
| `cargo fmt --all` | 0 |
| `cargo doc` unresolved links | 0 |
| `payload_pool` | 7 passed |
| `intra_process` | 18 passed |
| `payload_pool_compat` | 5 passed |
| `rmw-zenoh-rs` build | 0 errors |

The clippy result is the one that matters, and it is measured rather than argued: **with `impl Publishable for T` present, the lint fires twice and clippy fails; with it removed, the same call site compiles and clippy passes at zero errors.** The positive control is what makes the second half meaningful.

## What fails without this

Nothing. **No failing baseline: this is ergonomics.** The justification is that hiroz's publish surface should read like the ROS API its users come from, and that Rust's type system already carries the distinction three names spelled out.

## Evidence

At `32b3934f`, on the worker: `cargo fmt --all --check` clean, `clippy -p hiroz --all-targets -- -D warnings` at 0 errors, `cargo doc` with **0 unresolved links**, `payload_pool` 7/7, `intra_process` **23/23** with the executed-test count printed (`ran=23`) so an empty binary cannot read as a pass. `rmw-zenoh-rs` — the C ABI consumer — builds clean; that was measured at `28f343e6`, and the only change since is a comment.


