### PR TITLE
fix(ffi): regenerate hiroz_ffi.h to match the Rust FFI surface

### DIFF
--- a/crates/hiroz-go/hiroz/hiroz_ffi.h
+++ b/crates/hiroz-go/hiroz/hiroz_ffi.h
@@ -11,10 +11,28 @@
 #define hiroz_ZENOH_EVENT_ID_MAX 11
 
 /**
- * Default depth for KEEP_LAST when SYSTEM_DEFAULT (depth=0) is used
- * This matches ROS 2 and rmw_zenoh_cpp behavior
+ * Default depth for `KeepLast` when SYSTEM_DEFAULT (depth=0) is used.
+ * Matches rclcpp's default of 10. Note this is distinct from
+ * [`KEEP_ALL_CACHE_DEPTH`] below, which is the rmw_zenoh-aligned cap
+ * applied to `KeepAll` when mapped to zenoh-ext's `cache.max_samples`.
  */
 #define hiroz_DEFAULT_HISTORY_DEPTH 10
+
+/**
+ * Cache/history depth used when a TransientLocal endpoint carries
+ * `QosHistory::KeepAll` (no inherent depth) or `KeepLast(0)`.
+ *
+ * Matches rmw_zenoh_cpp's `RMW_ZENOH_DEFAULT_HISTORY_DEPTH = 42`
+ * (`rmw_zenoh_cpp/src/detail/qos.cpp:27`), which is the value
+ * rmw_zenoh's `best_available_qos` substitutes for a zero-valued
+ * `qos.depth` before passing it to
+ * `AdvancedPublisherOptions::CacheOptions::max_samples`.
+ *
+ * This is intentionally a *finite* cap that mirrors rmw_zenoh's
+ * pragmatic behaviour rather than the DDS KEEP_ALL spec's "keep
+ * everything" semantics.
+ */
+#define hiroz_KEEP_ALL_CACHE_DEPTH 42
 
 /**
  * Default shared memory pool size (10 MB).
@@ -28,6 +46,31 @@
  * Matches rmw_zenoh_cpp default for compatibility.
  */
 #define hiroz_DEFAULT_SHM_THRESHOLD 512
+
+/**
+ * Constant for ListParameters: recursively get parameters with unlimited depth.
+ */
+#define hiroz_DEPTH_RECURSIVE 0
+
+#define hiroz_NOT_SET 0
+
+#define hiroz_BOOL 1
+
+#define hiroz_INTEGER 2
+
+#define hiroz_DOUBLE 3
+
+#define hiroz_STRING 4
+
+#define hiroz_BYTE_ARRAY 5
+
+#define hiroz_BOOL_ARRAY 6
+
+#define hiroz_INTEGER_ARRAY 7
+
+#define hiroz_DOUBLE_ARRAY 8
+
+#define hiroz_STRING_ARRAY 9
 
 /**
  * Opaque action client handle for FFI
@@ -185,6 +228,11 @@ typedef struct hiroz_context_config_t {
    * Whether to enable logging
    */
   bool enable_logging;
+  /**
+   * Default namespace inherited by nodes created from this context (nullable).
+   * Added after all pre-existing fields to preserve ABI compatibility.
+   */
+  const char *namespace_;
 } hiroz_context_config_t;
 
 /**
@@ -288,6 +336,11 @@ typedef struct hiroz_subscriber_t {
  * Callback type for receiving messages
  */
 typedef void (*hiroz_MessageCallback)(uintptr_t user_data, const uint8_t *data, uintptr_t len);
+
+/**
+ * CDR encapsulation header for little-endian encoding.
+ */
+#define hiroz_CDR_HEADER_LE { 0, 1, 0, 0, }
 
 
 
@@ -630,8 +683,8 @@ int32_t hiroz_service_client_destroy(struct hiroz_service_client_t *client);
 
 /**
  * Wait until at least one matching service server is visible in the graph,
- * or `timeout_ms` elapses. Returns 0 if ready, -10 (ServiceTimeout) on
- * timeout, -1 (NullPointer) if `client_handle` is null.
+ * or `timeout_ms` elapses. Returns `Success` (0) if ready, `ServiceTimeout`
+ * (-10) on timeout, `NullPointer` (-1) if `client` is null.
  */
 int32_t hiroz_service_client_wait_for_service(struct hiroz_service_client_t *client_handle,
                                               uint64_t timeout_ms);


### PR DESCRIPTION
## Summary

The committed C header `crates/hiroz-go/hiroz/hiroz_ffi.h` has drifted from the
`#[repr(C)]` types in `crates/hiroz/src/ffi`. The header wasn't regenerated after
several FFI changes landed, so consumers compile against a stale ABI.

The consequential drift is in **`hiroz_context_config_t`**. The Rust
`CContextConfig` ends with a `namespace: *const c_char` field, read in
`hiroz_context_create_with_config`:

```rust
// crates/hiroz/src/ffi/context.rs
pub struct CContextConfig {
    ...
    pub enable_logging: bool,
    pub namespace: *const c_char,   // 12th field
}
...
if let Some(Ok(namespace)) = (!cfg.namespace.is_null()).then(|| cstr_to_str(cfg.namespace)) {
    builder = builder.with_namespace(namespace);
}
```

…but the committed header stops at `enable_logging` (11 fields):

```c
typedef struct hiroz_context_config_t {
  ...
  bool enable_logging;
} hiroz_context_config_t;   // no namespace_
```

A caller that allocates this struct from the header gets one **8 bytes smaller**
than the Rust side reads. `hiroz_context_create_with_config` then dereferences
`cfg.namespace` — memory just past the caller's allocation, i.e. an
uninitialised/garbage pointer — and passes it to `cstr_to_str()`. That is UB;
in practice it presents either as a segfault during context creation or as a
spurious `-16 "failed to build entity: context"` when the garbage happens to be
a non-null but invalid pointer.

The header had also fallen behind on constants that exist in the FFI surface
(`KEEP_ALL_CACHE_DEPTH`, the parameter-type enum values, `DEPTH_RECURSIVE`) and
on a couple of doc comments.

## Fix

Regenerate the header from the crate's own `build.rs` cbindgen path
(`cargo build --features ffi`, cbindgen 0.29.4). No hand edits — the diff is
purely generator output, and every added item corresponds to a real exported
Rust symbol (verified: `KEEP_ALL_CACHE_DEPTH` in `qos`, `DEPTH_RECURSIVE` in
`parameter/wire_types`, `namespace_` in `CContextConfig`). Nothing is removed.

## How we hit this

We consume `libhiroz.a` from Go via cgo. Against a busy `rmw_zenoh_cpp` router,
`hiroz_context_create_with_config` intermittently returned `-16` / segfaulted.
The 8-byte struct mismatch was one of the contributing ABI hazards we traced
(and it is latent for *any* header-based consumer, not just ours).

## Suggested follow-up (optional, not in this PR)

To stop the header re-drifting, consider a CI check that regenerates the header
and fails if it differs from the committed copy (`cbindgen ... --output - | diff`),
or make `build.rs` hard-error when the `ffi` feature is set but `cbindgen` is
absent (it currently prints a warning and silently ships the stale header).

## Verification

- `cargo build --release --features ffi,jazzy --no-default-features -p hiroz`
  regenerates the header cleanly; struct tail now ends `const char *namespace_;`.
- Diff is +57/-4, additions only, all backed by real FFI symbols.
