### PR TITLE
feat(ffi): expose SHM provider through the FFI (+ hiroz-go WithShmPool) 

### DIFF
--- a/crates/hiroz-go/hiroz/context.go
+++ b/crates/hiroz-go/hiroz/context.go
@@ -44,6 +44,7 @@ type ContextBuilder struct {
 	jsonConfig           string
 	remapRules           []string
 	enableLogging        bool
+	shmPoolBytes         uint64
 	hasAdvancedConfig    bool
 }
 
@@ -118,6 +119,19 @@ func (b *ContextBuilder) WithLogging() *ContextBuilder {
 	return b
 }
 
+// WithShmPool attaches a shared-memory provider of the given size (bytes),
+// making the session SHM-capable so payloads can be published and received by
+// shared-memory reference (zero-copy) instead of being copied over the
+// transport. A non-zero pool is required for SHM transport to negotiate —
+// enabling SHM via config alone is not sufficient. Pass 0 (the default) to
+// disable. A receiver needs only a small pool (it maps the publisher's
+// segments); a publisher needs a pool large enough for its in-flight payloads.
+func (b *ContextBuilder) WithShmPool(bytes uint64) *ContextBuilder {
+	b.shmPoolBytes = bytes
+	b.hasAdvancedConfig = true
+	return b
+}
+
 // Build creates the context
 func (b *ContextBuilder) Build() (*Context, error) {
 	var handle *C.hiroz_context_t
@@ -135,6 +149,7 @@ func (b *ContextBuilder) Build() (*Context, error) {
 		cfg.disable_multicast_scouting = C.bool(b.disableMulticast)
 		cfg.connect_to_local_zenohd = C.bool(b.connectToLocalZenohd)
 		cfg.enable_logging = C.bool(b.enableLogging)
+		cfg.shm_pool_bytes = C.uintptr_t(b.shmPoolBytes)
 
 		// Config file
 		if b.configFile != "" {

--- a/crates/hiroz-go/hiroz/hiroz_ffi.h
+++ b/crates/hiroz-go/hiroz/hiroz_ffi.h
@@ -11,10 +11,28 @@
 #define hiroz_ZENOH_EVENT_ID_MAX 11
 
 /**
- * Default depth for KEEP_LAST when SYSTEM_DEFAULT (depth=0) is used
- * This matches ROS 2 and rmw_zenoh_cpp behavior
+ * Default depth for `KeepLast` when SYSTEM_DEFAULT (depth=0) is used.
+ * Matches rclcpp's default of 10. Note this is distinct from
+ * [`KEEP_ALL_CACHE_DEPTH`] below, which is the rmw_zenoh-aligned cap
+ * applied to `KeepAll` when mapped to zenoh-ext's `cache.max_samples`.
  */
 #define hiroz_DEFAULT_HISTORY_DEPTH 10
+
+/**
+ * Cache/history depth used when a TransientLocal endpoint carries
+ * `QosHistory::KeepAll` (no inherent depth) or `KeepLast(0)`.
+ *
+ * Matches rmw_zenoh_cpp's `RMW_ZENOH_DEFAULT_HISTORY_DEPTH = 42`
+ * (`rmw_zenoh_cpp/src/detail/qos.cpp:27`), which is the value
+ * rmw_zenoh's `best_available_qos` substitutes for a zero-valued
+ * `qos.depth` before passing it to
+ * `AdvancedPublisherOptions::CacheOptions::max_samples`.
+ *
+ * This is intentionally a *finite* cap that mirrors rmw_zenoh's
+ * pragmatic behaviour rather than the DDS KEEP_ALL spec's "keep
+ * everything" semantics.
+ */
+#define hiroz_KEEP_ALL_CACHE_DEPTH 42
 
 /**
  * Default shared memory pool size (10 MB).
@@ -28,6 +46,31 @@
  * Matches rmw_zenoh_cpp default for compatibility.
  */
 #define hiroz_DEFAULT_SHM_THRESHOLD 512
+
+/**
+ * Constant for ListParameters: recursively get parameters with unlimited depth.
+ */
+#define hiroz_DEPTH_RECURSIVE 0
+
+#define hiroz_NOT_SET 0
+
+#define hiroz_BOOL 1
+
+#define hiroz_INTEGER 2
+
+#define hiroz_DOUBLE 3
+
+#define hiroz_STRING 4
+
+#define hiroz_BYTE_ARRAY 5
+
+#define hiroz_BOOL_ARRAY 6
+
+#define hiroz_INTEGER_ARRAY 7
+
+#define hiroz_DOUBLE_ARRAY 8
+
+#define hiroz_STRING_ARRAY 9
 
 /**
  * Opaque action client handle for FFI
@@ -185,6 +228,20 @@ typedef struct hiroz_context_config_t {
    * Whether to enable logging
    */
   bool enable_logging;
+  /**
+   * Default namespace inherited by nodes created from this context (nullable).
+   * Added after all pre-existing fields to preserve ABI compatibility.
+   */
+  const char *namespace_;
+  /**
+   * Shared-memory pool size in bytes. When non-zero, the context attaches an
+   * SHM provider of this size, making the session SHM-capable so it can
+   * publish and receive payloads by shared-memory reference (zero-copy)
+   * instead of copying them over the transport. 0 disables SHM (default).
+   * Mirrors `ZContextBuilder::with_shm_pool_size`. Added after all
+   * pre-existing fields to preserve ABI compatibility.
+   */
+  uintptr_t shm_pool_bytes;
 } hiroz_context_config_t;
 
 /**
@@ -288,6 +345,11 @@ typedef struct hiroz_subscriber_t {
  * Callback type for receiving messages
  */
 typedef void (*hiroz_MessageCallback)(uintptr_t user_data, const uint8_t *data, uintptr_t len);
+
+/**
+ * CDR encapsulation header for little-endian encoding.
+ */
+#define hiroz_CDR_HEADER_LE { 0, 1, 0, 0, }
 
 
 
@@ -630,8 +692,8 @@ int32_t hiroz_service_client_destroy(struct hiroz_service_client_t *client);
 
 /**
  * Wait until at least one matching service server is visible in the graph,
- * or `timeout_ms` elapses. Returns 0 if ready, -10 (ServiceTimeout) on
- * timeout, -1 (NullPointer) if `client_handle` is null.
+ * or `timeout_ms` elapses. Returns `Success` (0) if ready, `ServiceTimeout`
+ * (-10) on timeout, `NullPointer` (-1) if `client` is null.
  */
 int32_t hiroz_service_client_wait_for_service(struct hiroz_service_client_t *client_handle,
                                               uint64_t timeout_ms);

--- a/crates/hiroz/src/ffi/context.rs
+++ b/crates/hiroz/src/ffi/context.rs
@@ -37,6 +37,13 @@ pub struct CContextConfig {
     /// Default namespace inherited by nodes created from this context (nullable).
     /// Added after all pre-existing fields to preserve ABI compatibility.
     pub namespace: *const c_char,
+    /// Shared-memory pool size in bytes. When non-zero, the context attaches an
+    /// SHM provider of this size, making the session SHM-capable so it can
+    /// publish and receive payloads by shared-memory reference (zero-copy)
+    /// instead of copying them over the transport. 0 disables SHM (default).
+    /// Mirrors `ZContextBuilder::with_shm_pool_size`. Added after all
+    /// pre-existing fields to preserve ABI compatibility.
+    pub shm_pool_bytes: usize,
 }
 
 /// Create a new hiroz context with default config (convenience)
@@ -84,6 +91,20 @@ pub unsafe extern "C" fn hiroz_context_create_with_config(
         if let Some(Ok(namespace)) = (!cfg.namespace.is_null()).then(|| cstr_to_str(cfg.namespace))
         {
             builder = builder.with_namespace(namespace);
+        }
+
+        // Shared memory: attach an SHM provider of the requested size so the
+        // session is SHM-capable (zero-copy publish/receive). A non-zero pool is
+        // required for SHM transport to negotiate — enabling it via config alone
+        // is not sufficient.
+        if cfg.shm_pool_bytes > 0 {
+            match builder.with_shm_pool_size(cfg.shm_pool_bytes) {
+                Ok(b) => builder = b,
+                Err(e) => {
+                    tracing::warn!("hiroz: Failed to configure SHM pool: {}", e);
+                    return std::ptr::null_mut();
+                }
+            }
         }
 
         // Config file


### PR DESCRIPTION
## Summary

The Rust API supports shared memory — `ZContextBuilder::with_shm_pool_size()` /
`with_shm_config()` and the whole `shm` module — but the **C FFI never surfaced
it**. `hiroz_context_config_t` has no SHM field and
`hiroz_context_create_with_config` never attaches a provider, so **no FFI
consumer (Go/C/Python) can make a session SHM-capable.**

This matters because in zenoh 1.9 a session only negotiates SHM transport with a
peer if it has an **SHM provider attached**. Setting
`transport/shared_memory/enabled: true` via config alone is *not* sufficient — a
provider-less peer is treated as non-SHM and the router copies payloads out over
the transport. So an FFI consumer receiving large payloads (e.g. camera frames)
from an SHM-capable Rust publisher silently falls back to a full copy over TCP,
even with SHM "enabled".

## Changes

- **`CContextConfig`**: add `shm_pool_bytes: usize` (appended after existing
  fields → ABI-additive). When non-zero, `hiroz_context_create_with_config`
  attaches a provider via `builder.with_shm_pool_size(cfg.shm_pool_bytes)`,
  mirroring the Rust builder; `0` disables (default). Regenerated `hiroz_ffi.h`.
- **hiroz-go**: add `ContextBuilder.WithShmPool(bytes uint64)` and marshal it
  into the config struct.

Both mirror existing patterns (`with_shm_pool_size` already exists in the core;
the FFI error handling mirrors the `with_remap_rules` block).

## Sizing note for consumers

A **receiver** needs only a small pool — it maps the publisher's segments and
allocates nothing per message; the pool exists solely to make the session
SHM-capable. A **publisher** needs a pool large enough for its in-flight payloads.

## Verification

- `cargo build --features ffi` compiles the FFI change and regenerates
  `hiroz_ffi.h` with `uintptr_t shm_pool_bytes;` in `hiroz_context_config_t`.
- hiroz-go builds and links `WithShmPool` against the resulting staticlib.

## Provenance

Found consuming hiroz from Go (cgo) on a robot: a camera driver (Rust,
SHM-capable) published 20MP frames into SHM, but the Go consumer — unable to
attach a provider through the FFI — received them over TCP loopback (measured
~780 MB/s on `lo` during capture where SHM would be ~KB/s). This PR is the
missing FFI capability, not a workaround.
