### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       # Interop runs this wrapper, but only its success path. This runs the
       # retries, the mirror switch and the guards. See hiroz#308.
@@ -86,12 +86,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       # Linux-specific setup
       - name: Free Disk Space (Ubuntu)
         if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install Nix (Linux)
         if: runner.os == 'Linux'
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
@@ -111,7 +111,7 @@ jobs:
 
       - name: Setup Cachix (Linux)
         if: runner.os == 'Linux'
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -139,7 +139,7 @@ jobs:
       # macOS-specific setup
       - name: Install Rust toolchain (macOS)
         if: runner.os == 'macOS'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
         with:
           toolchain: stable
           components: clippy, rustfmt
@@ -152,13 +152,13 @@ jobs:
 
       - name: Install cargo-nextest (macOS)
         if: runner.os == 'macOS'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-nextest
 
       # Common setup
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ runner.os }}-pureRust-test
 
@@ -192,10 +192,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -206,14 +206,14 @@ jobs:
           swap-storage: false
 
       - name: Install Nix (Linux)
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -237,7 +237,7 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ runner.os }}-pureRust-shm
 
@@ -257,10 +257,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -271,14 +271,14 @@ jobs:
           swap-storage: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -300,12 +300,12 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ubuntu-latest-coverage
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-llvm-cov
 
@@ -323,7 +323,7 @@ jobs:
         shell: bash
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         continue-on-error: true
         with:
           files: lcov.info
@@ -342,12 +342,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       # Linux-specific setup
       - name: Free Disk Space (Ubuntu)
         if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -359,7 +359,7 @@ jobs:
 
       - name: Install Nix (Linux)
         if: runner.os == 'Linux'
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
@@ -367,7 +367,7 @@ jobs:
 
       - name: Setup Cachix (Linux)
         if: runner.os == 'Linux'
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -395,7 +395,7 @@ jobs:
       # macOS-specific setup
       - name: Install Rust toolchain (macOS)
         if: runner.os == 'macOS'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
         with:
           toolchain: stable
           target: wasm32-wasip2
@@ -409,7 +409,7 @@ jobs:
 
       # Common setup
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ runner.os }}-pureRust-checks-v2
 
@@ -515,15 +515,15 @@ jobs:
     # and running the binary is a separate question from whether the release
     # artifact can be produced.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
         with:
           targets: aarch64-unknown-linux-gnu
 
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-zigbuild
 
@@ -531,12 +531,12 @@ jobs:
         run: pip install ziglang
 
       - name: Install nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7  # v3
         with:
           version: "0.113.1"
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ubuntu-latest-hu-aarch64-cross
 
@@ -570,10 +570,10 @@ jobs:
     # and executes the documented commands against that install.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
         with:
           toolchain: stable
           target: wasm32-wasip2
@@ -588,7 +588,7 @@ jobs:
           nu --version
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ubuntu-latest-hu-docs-repro
 
@@ -662,10 +662,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -676,14 +676,14 @@ jobs:
           swap-storage: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -702,7 +702,7 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ubuntu-latest-wasm-plugin-tests
 
@@ -719,10 +719,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -733,14 +733,14 @@ jobs:
           swap-storage: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://hiroz.cachix.org
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -757,7 +757,7 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ubuntu-latest-python-stubs
 
@@ -779,25 +779,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: '1.23'
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
         with:
           toolchain: stable
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ runner.os }}-go-ffi
 
       - name: Install Nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7  # v3
         with:
           version: '0.102'
 
@@ -826,10 +826,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -840,7 +840,7 @@ jobs:
           swap-storage: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://ros.cachix.org https://hiroz.cachix.org
@@ -848,7 +848,7 @@ jobs:
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -876,7 +876,7 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ matrix.distro }}-python
 
@@ -884,7 +884,7 @@ jobs:
         run: find target -name 'build-script-build' -path '*pyo3-build-config*' -delete 2>/dev/null || true
 
       - name: Cache generated Python types
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: crates/hiroz-msgs/python/hiroz_msgs_py/types
           key: >-
@@ -950,10 +950,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         with:
           large-packages: true
           tool-cache: true
@@ -964,7 +964,7 @@ jobs:
           swap-storage: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
         with:
           extra_nix_config: |
             extra-substituters = https://ros.cachix.org https://hiroz.cachix.org
@@ -972,7 +972,7 @@ jobs:
             extra-trusted-public-keys = hiroz.cachix.org-1:wKJuqEckTG0DL3Df7Ly9OVsg5S5TGBHtvlPGs+vlqrY=
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
         with:
           name: hiroz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -997,7 +997,7 @@ jobs:
           echo "export CI=true" >> /tmp/nix-dev-env.sh
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           shared-key: ${{ matrix.distro }}-ros-v2
 

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
 
       - name: Build MkDocs
         run: nix develop '.#pureRust-ci' -c mkdocs build --strict
 
       - name: Check external links
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
         with:
           args: >-
             --root-dir ${{ github.workspace }}/site
@@ -36,7 +36,7 @@ jobs:
 
       - name: Open issue on link failures
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd  # v5
         with:
           title: 'docs: broken external links detected'
           content-filepath: ./lychee/out.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
 
       - name: Build MkDocs
         run: |
@@ -38,7 +38,7 @@ jobs:
           nix develop '.#pureRust-ci' -c nu scripts/check-example-coverage.nu
 
       - name: Check internal links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
         with:
           args: >-
             --offline
@@ -58,17 +58,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
 
       - name: Build MkDocs
         run: |
           nix develop '.#pureRust-ci' -c mkdocs build --strict
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Nix
         if: github.event.action != 'closed'
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31
 
       - name: Build MkDocs documentation
         if: github.event.action != 'closed'
@@ -37,7 +37,7 @@ jobs:
           nix develop '.#pureRust-ci' -c mkdocs build --strict
 
       - name: Deploy MkDocs preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
         with:
           source-dir: ./site
           preview-branch: gh-pages

--- a/.github/workflows/pr-draft-check.yml
+++ b/.github/workflows/pr-draft-check.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check PR author association
         id: check-author
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -37,7 +37,7 @@ jobs:
 
       - name: Verify external PR is draft or reviewed
         if: steps.check-author.outputs.is-external == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const isDraft = '${{ steps.check-author.outputs.is-draft }}' === 'true';
@@ -80,7 +80,7 @@ jobs:
           steps.check-author.outputs.is-external == 'true' &&
           steps.check-author.outputs.is-draft == 'false' &&
           steps.check-author.outputs.author-association == 'FIRST_TIME_CONTRIBUTOR'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     name: Build hiroz-msgs-py wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
 
       - name: Generate Python message types
         run: cargo build -p hiroz-msgs --features python_registry -j4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -34,7 +34,7 @@ jobs:
         working-directory: crates/hiroz-msgs/python
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: hiroz-msgs-py-dist
           path: crates/hiroz-msgs/python/dist/*
@@ -73,7 +73,7 @@ jobs:
             extra_args: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Prepare macOS build environment
         if: matrix.os == 'macos-latest'
@@ -84,7 +84,7 @@ jobs:
           echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1
         with:
           target: ${{ matrix.target }}
           args: >-
@@ -116,7 +116,7 @@ jobs:
           done
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: hiroz-py-${{ matrix.distro }}-${{ matrix.target }}
           path: crates/hiroz-py/dist/*
@@ -158,10 +158,10 @@ jobs:
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
         with:
           # wasm32-wasip2 builds the hu plugins. They are platform-independent,
           # so only the primary leg (below) actually packages them.
@@ -177,7 +177,7 @@ jobs:
           pip install ziglang
       - name: Install cargo-zigbuild (aarch64 Linux)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-zigbuild
 
@@ -201,7 +201,7 @@ jobs:
             --target ${{ matrix.target }}
 
       - name: Install nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7  # v3
         with:
           version: "0.113.1"
 
@@ -240,7 +240,7 @@ jobs:
             --out bin-dist
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}
           path: bin-dist/*
@@ -256,15 +256,15 @@ jobs:
     # leg. Building it in the per-target matrix would have three legs racing to
     # upload the same asset name.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
         with:
           targets: wasm32-wasip2
 
       - name: Install nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7  # v3
         with:
           version: "0.113.1"
 
@@ -321,7 +321,7 @@ jobs:
           done
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: bin-hu-plugins
           path: hu-dist/*
@@ -353,10 +353,10 @@ jobs:
             distro: humble
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
 
       - name: Install Rust target (Linux cross-compile only)
         if: matrix.target == 'aarch64-unknown-linux-gnu' && matrix.os == 'ubuntu-latest'
@@ -368,7 +368,7 @@ jobs:
           pip install ziglang
       - name: Install cargo-zigbuild (aarch64 Linux)
         if: matrix.target == 'aarch64-unknown-linux-gnu' && matrix.os == 'ubuntu-latest'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-zigbuild
 
@@ -409,7 +409,7 @@ jobs:
           cp crates/hiroz-go/hiroz/hiroz_ffi.h "go-dist/hiroz_ffi.h"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: libhiroz-${{ matrix.distro }}-${{ matrix.target }}
           path: go-dist/*
@@ -420,18 +420,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
       - name: Download hiroz-msgs-py
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: hiroz-msgs-py-dist
           path: dist/
 
       - name: Download hiroz-py wheel (jazzy, x86_64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: hiroz-py-jazzy-x86_64-unknown-linux-gnu
           path: dist/
@@ -473,10 +473,10 @@ jobs:
       # and the next step dies on `cd: dist: No such file or directory`. This
       # job had never run -- release.yml triggers only on a `v*` tag -- so the
       # ordering was wrong from the day it was written and nothing could say so.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Download hu binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: ${{ matrix.artifact }}
           path: dist/
@@ -484,7 +484,7 @@ jobs:
       # The .wasm plugins are wasm32-wasip2 and platform-independent, so both
       # legs consume the single artifact the one plugins job produced.
       - name: Download hu plugins
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: bin-hu-plugins
           path: dist/
@@ -550,15 +550,15 @@ jobs:
     needs: [build-go-libs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: "1.23"
 
       - name: Download libhiroz (jazzy, x86_64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: libhiroz-jazzy-x86_64-unknown-linux-gnu
           path: dist/
@@ -583,12 +583,12 @@ jobs:
     needs: [smoke-test-python, smoke-test-binaries, smoke-test-go]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@3d96a18cc4ec17e9dc69ddcc424ccafaf1f78ce2  # v4
         id: git-cliff
         with:
           config: cliff.toml
@@ -598,27 +598,27 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Download hiroz-msgs-py artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: hiroz-msgs-py-dist
           path: dist/
 
       - name: Download hiroz-py wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: hiroz-py-*
           path: dist/
           merge-multiple: true
 
       - name: Download binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: bin-*
           path: dist/
           merge-multiple: true
 
       - name: Download libhiroz artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: libhiroz-*
           path: dist/
@@ -669,7 +669,7 @@ jobs:
       # assets for a download test. `prerelease` comes from the tag shape, so a
       # rehearsal tag never takes the "Latest" badge.
       - name: Create GitHub Release (draft)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           draft: true
           name: ${{ github.ref_name }}
@@ -705,7 +705,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -727,7 +727,7 @@ jobs:
       - name: Import test
         run: .venv/bin/python -c "import hiroz_py; print('hiroz_py install-from-release ok')"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       # Install `hu` from the live release URLs, the way a reader of
       # docs/tools/hu-install.md does. This is the only test that exercises
@@ -795,12 +795,12 @@ jobs:
           echo "ok — the documented one-liner URL serves this tag's installer"
 
       - name: Install nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7  # v3
         with:
           version: "0.113.1"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
 
       # From the source checkout, not the artifact: `hu` cannot generate its own
       # traffic, because no release ships message definitions (#309, G2). With
@@ -885,13 +885,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
 
       - name: Authenticate with crates.io (trusted publishing)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1
         id: auth
 
       - name: Publish core crates

--- a/.github/workflows/rmw-zenoh-rs.yml
+++ b/.github/workflows/rmw-zenoh-rs.yml
@@ -63,12 +63,12 @@ jobs:
             ros-jazzy-osrf-testing-tools-cpp
 
       - name: Checkout hiroz
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           path: hiroz
 
       - name: Checkout rcl fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           repository: YuanYuYuan/rcl
           ref: patch-rmwz/jazzy
@@ -80,7 +80,7 @@ jobs:
           cp -r $GITHUB_WORKSPACE/rcl ws/src/rcl
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
 
       - name: Install Nushell
         run: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: rmw-zenoh-rs-test-results
           path: ws/log/latest_test/

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -15,7 +15,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825  # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,14 @@ jobs:
     steps:
       # Must stay first: the apt steps run `scripts/ci/apt-retry.sh`, and the
       # cache key hashes this file, yielding a constant on an empty workspace.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Compute weekly cache key
         id: cache-week
         run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache apt packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: /var/cache/apt/archives
           key: apt-${{ matrix.distro }}-v3-${{ hashFiles('.github/workflows/test.yml') }}
@@ -75,7 +75,7 @@ jobs:
       # going stale; a miss re-fetches. The rate that justified it does not
       # reproduce -- see hiroz#308.
       - name: Cache apt package lists
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: /var/lib/apt/lists
           key: apt-lists-${{ matrix.distro }}-${{ steps.cache-week.outputs.week }}
@@ -219,18 +219,18 @@ jobs:
       # in the matrix -- so the four legs shared one target/. humble is the only
       # 22.04 image, so it restored proc-macros the 24.04 legs had built and
       # failed with "GLIBC_2.39 not found". The cache below is per-distro.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1
         with:
           cache: false
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2
         with:
           # -v2 discards entries saved while the shared cache above was in use.
           shared-key: ${{ matrix.distro }}-interop-v2
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff  # v2
         with:
           tool: cargo-nextest
 
@@ -256,7 +256,7 @@ jobs:
               --no-tests=warn
           fi
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: '1.23'
           cache: false


### PR DESCRIPTION
## Summary
- The organization now enforces a policy that every GitHub Action referenced in a workflow must be pinned to a full 40-character commit SHA, not a version tag or branch.
- None of the existing workflows were pinned that way, so every job in every workflow was failing within seconds at the "prepare workflow" step with an error like `The actions actions/checkout@v4, ... are not allowed in ZettaScaleLabs/hiroz because all actions must be pinned to a full-length commit SHA.` This blocked CI repo-wide, for every PR, regardless of the PR's own content.

## Key Changes
- Resolved every `uses: <owner>/<repo>@<tag-or-branch>` reference across all nine workflow files (`.github/workflows/*.yml`) to the full commit SHA that ref currently points at.
- Kept the original tag/branch as a trailing comment (`uses: actions/checkout@<sha>  # v4`), the standard convention so a human reading the workflow (and tools like Dependabot/Renovate) still know what version it is.
- No workflow logic, triggers, or job structure changed — only the `uses:` lines.

## What fails without this
Every CI run on every PR fails at the "prepare workflow" step within 2-4 seconds, before any real step executes, with the "not allowed ... must be pinned to a full-length commit SHA" error. This is not related to any PR's code changes.

## Breaking Changes
None.
