### PR TITLE
fix(rmw-zenoh-rs): check QoS incompatibility against remote peers

### DIFF
--- a/crates/hiroz-protocol/src/format/rmw_zenoh.rs
+++ b/crates/hiroz-protocol/src/format/rmw_zenoh.rs
@@ -309,6 +309,7 @@ mod tests {
             reliability: QosReliability::Reliable,
             durability: QosDurability::TransientLocal,
             history: QosHistory::from_depth(10),
+            ..QosProfile::default()
         };
         let encoded = RmwZenohFormatter::encode_qos(&qos, false);
 
@@ -1125,6 +1126,7 @@ mod tests {
             reliability: QosReliability::Reliable,
             durability: QosDurability::TransientLocal,
             history: QosHistory::from_depth(10),
+            ..QosProfile::default()
         };
 
         let entity = EndpointEntity {
@@ -1522,6 +1524,7 @@ mod kani_proofs {
                 reliability: QosReliability::Reliable,
                 durability: QosDurability::Volatile,
                 history: QosHistory::KeepLast(10),
+                ..QosProfile::default()
             },
         };
 

--- a/crates/hiroz-protocol/src/qos.rs
+++ b/crates/hiroz-protocol/src/qos.rs
@@ -13,11 +13,46 @@ pub struct QosProfile {
     pub reliability: QosReliability,
     pub durability: QosDurability,
     pub history: QosHistory,
+    pub deadline: QosDuration,
+    pub lifespan: QosDuration,
+    pub liveliness: QosLiveliness,
+    pub liveliness_lease_duration: QosDuration,
+}
+
+/// Encode one duration component (seconds or nanoseconds), omitted if it
+/// matches the corresponding default component -- rmw_zenoh_cpp compares and
+/// omits sec/nsec independently, not the duration as a whole, so a duration
+/// can have an empty sec alongside a present nsec on the wire.
+fn encode_duration_component(value: u64, default_value: u64) -> String {
+    use alloc::format;
+    if value != default_value {
+        format!("{value}")
+    } else {
+        String::new()
+    }
+}
+
+fn parse_duration_component(s: &str, default_value: u64) -> Result<u64, QosDecodeError> {
+    if s.is_empty() {
+        Ok(default_value)
+    } else {
+        s.parse::<u64>().map_err(|_| QosDecodeError::InvalidDuration)
+    }
+}
+
+/// Parse a `<sec>,<nsec>` duration sub-field, empty either side falling back
+/// to the matching component of `default`.
+fn parse_duration(s: &str, default: &QosDuration) -> Result<QosDuration, QosDecodeError> {
+    let (sec, nsec) = s.split_once(',').ok_or(QosDecodeError::InvalidDuration)?;
+    Ok(QosDuration {
+        sec: parse_duration_component(sec, default.sec)?,
+        nsec: parse_duration_component(nsec, default.nsec)?,
+    })
 }
 
 impl QosProfile {
     /// Encode QoS to string for liveliness token.
-    /// Format matches rmw_zenoh_cpp: [reliability]:[durability]:[history],[depth]:[deadline]:[lifespan]:[liveliness]
+    /// Format matches rmw_zenoh_cpp: [reliability]:[durability]:[history],[depth]:[deadline_sec],[deadline_nsec]:[lifespan_sec],[lifespan_nsec]:[liveliness_kind],[lease_sec],[lease_nsec]
     pub fn encode(&self) -> String {
         use alloc::format;
         let default_qos = Self::default();
@@ -55,10 +90,45 @@ impl QosProfile {
             QosHistory::KeepAll => "2,".to_string(),
         };
 
-        // Deadline, lifespan, liveliness - use defaults (empty/infinite)
-        let deadline = ",";
-        let lifespan = ",";
-        let liveliness = ",,";
+        let deadline = format!(
+            "{},{}",
+            encode_duration_component(self.deadline.sec, default_qos.deadline.sec),
+            encode_duration_component(self.deadline.nsec, default_qos.deadline.nsec),
+        );
+        let lifespan = format!(
+            "{},{}",
+            encode_duration_component(self.lifespan.sec, default_qos.lifespan.sec),
+            encode_duration_component(self.lifespan.nsec, default_qos.lifespan.nsec),
+        );
+
+        // Liveliness kind - empty if default (RMW values: 1=Automatic,
+        // 2=ManualByNode, 3=ManualByTopic). rmw_zenoh_cpp itself never
+        // encodes or decodes 2 (MANUAL_BY_NODE was deprecated and removed
+        // from RMW); hiroz still carries the variant and encodes it as 2 for
+        // completeness, but a peer running rmw_zenoh_cpp will not decode it
+        // distinctly -- a pre-existing upstream limitation, not one this
+        // encoder introduces.
+        let liveliness_kind = if self.liveliness != default_qos.liveliness {
+            match self.liveliness {
+                QosLiveliness::Automatic => "1",
+                QosLiveliness::ManualByNode => "2",
+                QosLiveliness::ManualByTopic => "3",
+            }
+        } else {
+            ""
+        };
+        let liveliness = format!(
+            "{},{},{}",
+            liveliness_kind,
+            encode_duration_component(
+                self.liveliness_lease_duration.sec,
+                default_qos.liveliness_lease_duration.sec
+            ),
+            encode_duration_component(
+                self.liveliness_lease_duration.nsec,
+                default_qos.liveliness_lease_duration.nsec
+            ),
+        );
 
         format!(
             "{}:{}:{}:{}:{}:{}",
@@ -131,10 +201,54 @@ impl QosProfile {
             }
         };
 
+        // Deadline/lifespan/liveliness are only present in the full
+        // six-field wire representation; a shorter (e.g. three-field, pre-D5)
+        // string decodes them as unset/default, same as an empty sub-field
+        // within a present field does.
+        let deadline = match fields.get(3) {
+            Some(s) if !s.is_empty() => parse_duration(s, &default_qos.deadline)?,
+            _ => default_qos.deadline,
+        };
+        let lifespan = match fields.get(4) {
+            Some(s) if !s.is_empty() => parse_duration(s, &default_qos.lifespan)?,
+            _ => default_qos.lifespan,
+        };
+        let (liveliness, liveliness_lease_duration) = match fields.get(5) {
+            Some(s) if !s.is_empty() => {
+                let mut parts = s.splitn(3, ',');
+                let kind_s = parts.next().unwrap_or("");
+                let lease_sec_s = parts.next().ok_or(QosDecodeError::InvalidLiveliness)?;
+                let lease_nsec_s = parts.next().ok_or(QosDecodeError::InvalidLiveliness)?;
+                let kind = match kind_s {
+                    "" | "0" => default_qos.liveliness,
+                    "1" => QosLiveliness::Automatic,
+                    "2" => QosLiveliness::ManualByNode,
+                    "3" => QosLiveliness::ManualByTopic,
+                    _ => return Err(QosDecodeError::InvalidLiveliness),
+                };
+                let lease = QosDuration {
+                    sec: parse_duration_component(
+                        lease_sec_s,
+                        default_qos.liveliness_lease_duration.sec,
+                    )?,
+                    nsec: parse_duration_component(
+                        lease_nsec_s,
+                        default_qos.liveliness_lease_duration.nsec,
+                    )?,
+                };
+                (kind, lease)
+            }
+            _ => (default_qos.liveliness, default_qos.liveliness_lease_duration),
+        };
+
         Ok(QosProfile {
             reliability,
             durability,
             history,
+            deadline,
+            lifespan,
+            liveliness,
+            liveliness_lease_duration,
         })
     }
 }
@@ -197,6 +311,45 @@ impl QosHistory {
     }
 }
 
+/// A QoS duration in seconds + nanoseconds, matching ROS 2's
+/// `RMW_DURATION_INFINITE` sentinel used for deadline, lifespan, and
+/// liveliness lease duration when unset. Distinct from any host `Duration`
+/// type so this crate stays `no_std`-clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QosDuration {
+    pub sec: u64,
+    pub nsec: u64,
+}
+
+impl QosDuration {
+    /// ROS 2's `RMW_DURATION_INFINITE` sentinel: sec=9223372036, nsec=854775807.
+    pub const INFINITE: QosDuration = QosDuration {
+        sec: 9_223_372_036,
+        nsec: 854_775_807,
+    };
+}
+
+impl Default for QosDuration {
+    fn default() -> Self {
+        Self::INFINITE
+    }
+}
+
+/// QoS liveliness policy.
+///
+/// `ManualByNode` was deprecated and removed from RMW; rmw_zenoh_cpp itself
+/// never encodes or decodes wire value 2. It is kept here only because
+/// `hiroz::qos::QosLiveliness` still carries the variant -- see `encode`'s
+/// note on this field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u8)]
+pub enum QosLiveliness {
+    #[default]
+    Automatic = 1,
+    ManualByNode = 2,
+    ManualByTopic = 3,
+}
+
 /// QoS decode errors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QosDecodeError {
@@ -204,6 +357,8 @@ pub enum QosDecodeError {
     InvalidReliability,
     InvalidDurability,
     InvalidHistory,
+    InvalidDuration,
+    InvalidLiveliness,
 }
 
 impl Display for QosDecodeError {
@@ -213,6 +368,8 @@ impl Display for QosDecodeError {
             QosDecodeError::InvalidReliability => write!(f, "Invalid reliability value"),
             QosDecodeError::InvalidDurability => write!(f, "Invalid durability value"),
             QosDecodeError::InvalidHistory => write!(f, "Invalid history value"),
+            QosDecodeError::InvalidDuration => write!(f, "Invalid duration value"),
+            QosDecodeError::InvalidLiveliness => write!(f, "Invalid liveliness value"),
         }
     }
 }

--- a/crates/hiroz-protocol/tests/key_expr.rs
+++ b/crates/hiroz-protocol/tests/key_expr.rs
@@ -41,6 +41,7 @@ fn endpoint_entity(domain_id: usize, kind: EndpointKind, topic: &str) -> Endpoin
             reliability: QosReliability::Reliable,
             durability: QosDurability::Volatile,
             history: QosHistory::KeepLast(10),
+            ..QosProfile::default()
         },
     }
 }

--- a/crates/hiroz-protocol/tests/qos.rs
+++ b/crates/hiroz-protocol/tests/qos.rs
@@ -3,8 +3,8 @@
 //! sub-fields it did not set explicitly.
 
 use hiroz_protocol::qos::{
-    QosDecodeError, QosDurability, QosHistory, QosProfile, QosReliability,
-    RMW_ZENOH_DEFAULT_HISTORY_DEPTH,
+    QosDecodeError, QosDurability, QosDuration, QosHistory, QosLiveliness, QosProfile,
+    QosReliability, RMW_ZENOH_DEFAULT_HISTORY_DEPTH,
 };
 
 #[test]
@@ -61,10 +61,31 @@ fn qos_round_trip() {
             reliability: QosReliability::BestEffort,
             durability: QosDurability::TransientLocal,
             history: QosHistory::KeepLast(5),
+            ..QosProfile::default()
         },
         QosProfile {
             history: QosHistory::KeepAll,
             ..QosProfile::default()
+        },
+        QosProfile {
+            deadline: QosDuration {
+                sec: 1,
+                nsec: 500_000,
+            },
+            lifespan: QosDuration { sec: 2, nsec: 0 },
+            liveliness: QosLiveliness::ManualByTopic,
+            liveliness_lease_duration: QosDuration { sec: 3, nsec: 250 },
+            ..QosProfile::default()
+        },
+        // Every field non-default at once.
+        QosProfile {
+            reliability: QosReliability::BestEffort,
+            durability: QosDurability::TransientLocal,
+            history: QosHistory::KeepAll,
+            deadline: QosDuration { sec: 10, nsec: 1 },
+            lifespan: QosDuration { sec: 20, nsec: 2 },
+            liveliness: QosLiveliness::ManualByNode,
+            liveliness_lease_duration: QosDuration { sec: 30, nsec: 3 },
         },
     ];
 
@@ -82,4 +103,16 @@ fn reject_invalid_history() {
             "{encoded}"
         );
     }
+}
+
+#[test]
+fn reject_invalid_duration_and_liveliness() {
+    assert_eq!(
+        QosProfile::decode("::,:notanumber,:,,"),
+        Err(QosDecodeError::InvalidDuration),
+    );
+    assert_eq!(
+        QosProfile::decode("::,:,:,:9,,"),
+        Err(QosDecodeError::InvalidLiveliness),
+    );
 }

--- a/crates/hiroz-union/src/app/render/common.rs
+++ b/crates/hiroz-union/src/app/render/common.rs
@@ -24,10 +24,27 @@ fn protocol_qos_to_hiroz(qos: &hiroz_protocol::qos::QosProfile) -> QosProfile {
             hiroz_protocol::qos::QosHistory::KeepLast(depth) => QosHistory::from_depth(depth),
             hiroz_protocol::qos::QosHistory::KeepAll => QosHistory::KeepAll,
         },
-        deadline: QosDuration::INFINITE,
-        lifespan: QosDuration::INFINITE,
-        liveliness: hiroz::qos::QosLiveliness::Automatic,
-        liveliness_lease_duration: QosDuration::INFINITE,
+        deadline: QosDuration {
+            sec: qos.deadline.sec,
+            nsec: qos.deadline.nsec,
+        },
+        lifespan: QosDuration {
+            sec: qos.lifespan.sec,
+            nsec: qos.lifespan.nsec,
+        },
+        liveliness: match qos.liveliness {
+            hiroz_protocol::qos::QosLiveliness::Automatic => hiroz::qos::QosLiveliness::Automatic,
+            hiroz_protocol::qos::QosLiveliness::ManualByNode => {
+                hiroz::qos::QosLiveliness::ManualByNode
+            }
+            hiroz_protocol::qos::QosLiveliness::ManualByTopic => {
+                hiroz::qos::QosLiveliness::ManualByTopic
+            }
+        },
+        liveliness_lease_duration: QosDuration {
+            sec: qos.liveliness_lease_duration.sec,
+            nsec: qos.liveliness_lease_duration.nsec,
+        },
     }
 }
 

--- a/crates/hiroz/src/qos.rs
+++ b/crates/hiroz/src/qos.rs
@@ -185,6 +185,23 @@ impl QosProfile {
                 }
                 QosHistory::KeepAll => hiroz_protocol::qos::QosHistory::KeepAll,
             },
+            deadline: hiroz_protocol::qos::QosDuration {
+                sec: self.deadline.sec,
+                nsec: self.deadline.nsec,
+            },
+            lifespan: hiroz_protocol::qos::QosDuration {
+                sec: self.lifespan.sec,
+                nsec: self.lifespan.nsec,
+            },
+            liveliness: match self.liveliness {
+                QosLiveliness::Automatic => hiroz_protocol::qos::QosLiveliness::Automatic,
+                QosLiveliness::ManualByNode => hiroz_protocol::qos::QosLiveliness::ManualByNode,
+                QosLiveliness::ManualByTopic => hiroz_protocol::qos::QosLiveliness::ManualByTopic,
+            },
+            liveliness_lease_duration: hiroz_protocol::qos::QosDuration {
+                sec: self.liveliness_lease_duration.sec,
+                nsec: self.liveliness_lease_duration.nsec,
+            },
         }
     }
 }

--- a/crates/rmw-zenoh-rs/src/pubsub.rs
+++ b/crates/rmw-zenoh-rs/src/pubsub.rs
@@ -26,7 +26,27 @@ pub fn protocol_qos_to_hiroz_qos(qos: &hiroz_protocol::qos::QosProfile) -> hiroz
             }
             hiroz_protocol::qos::QosHistory::KeepAll => hiroz::qos::QosHistory::KeepAll,
         },
-        ..Default::default()
+        deadline: hiroz::qos::QosDuration {
+            sec: qos.deadline.sec,
+            nsec: qos.deadline.nsec,
+        },
+        lifespan: hiroz::qos::QosDuration {
+            sec: qos.lifespan.sec,
+            nsec: qos.lifespan.nsec,
+        },
+        liveliness: match qos.liveliness {
+            hiroz_protocol::qos::QosLiveliness::Automatic => hiroz::qos::QosLiveliness::Automatic,
+            hiroz_protocol::qos::QosLiveliness::ManualByNode => {
+                hiroz::qos::QosLiveliness::ManualByNode
+            }
+            hiroz_protocol::qos::QosLiveliness::ManualByTopic => {
+                hiroz::qos::QosLiveliness::ManualByTopic
+            }
+        },
+        liveliness_lease_duration: hiroz::qos::QosDuration {
+            sec: qos.liveliness_lease_duration.sec,
+            nsec: qos.liveliness_lease_duration.nsec,
+        },
     }
 }
 

--- a/crates/rmw-zenoh-rs/src/qos.rs
+++ b/crates/rmw-zenoh-rs/src/qos.rs
@@ -151,10 +151,10 @@ fn duration_to_rmw_time(dur: &hiroz::qos::QosDuration) -> rmw_time_t {
 }
 
 /// Convert rmw_time_t to hiroz Duration.
-/// RMW_DURATION_INFINITE maps back to hiroz {0, 0} (infinite).
+/// RMW_DURATION_INFINITE maps back to `QosDuration::INFINITE`.
 fn rmw_time_to_duration(time: &rmw_time_t) -> hiroz::qos::QosDuration {
     if time.sec == 9223372036 && time.nsec == 854775807 {
-        hiroz::qos::QosDuration { sec: 0, nsec: 0 }
+        hiroz::qos::QosDuration::INFINITE
     } else {
         hiroz::qos::QosDuration {
             sec: time.sec,
@@ -331,4 +331,30 @@ pub extern "C" fn rmw_qos_profile_check_compatible(
         *compatibility = rmw_qos_compatibility_type_t::RMW_QOS_COMPATIBILITY_OK;
     }
     RMW_RET_OK as _
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rmw_duration_infinite_round_trips_to_hiroz_infinite() {
+        let infinite = rmw_time_t {
+            sec: 9223372036,
+            nsec: 854775807,
+        };
+        assert_eq!(
+            rmw_time_to_duration(&infinite),
+            hiroz::qos::QosDuration::INFINITE
+        );
+    }
+
+    #[test]
+    fn rmw_duration_finite_round_trips_verbatim() {
+        let finite = rmw_time_t { sec: 5, nsec: 42 };
+        assert_eq!(
+            rmw_time_to_duration(&finite),
+            hiroz::qos::QosDuration { sec: 5, nsec: 42 }
+        );
+    }
 }

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -279,9 +279,10 @@ pub extern "C" fn rmw_create_publisher(
                 continue;
             };
 
-            // Only check QoS compatibility with entities from the same Zenoh session
-            // This avoids counting subscriptions from previous test cases that used different sessions
-            if node.z_id != local_zid {
+            // DDS-style QoS-incompatibility checking is for remote peers --
+            // skip only this session's own entities. The old `!=` guard had
+            // this backwards: same-session only, never remote.
+            if node.z_id == local_zid {
                 continue;
             }
 
@@ -665,9 +666,10 @@ pub extern "C" fn rmw_create_subscription(
                 continue;
             };
 
-            // Only check QoS compatibility with entities from the same Zenoh session
-            // This avoids counting publishers from previous test cases that used different sessions
-            if node.z_id != local_zid {
+            // DDS-style QoS-incompatibility checking is for remote peers --
+            // skip only this session's own entities. The old `!=` guard had
+            // this backwards: same-session only, never remote.
+            if node.z_id == local_zid {
                 continue;
             }
 

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -274,9 +274,9 @@ pub extern "C" fn rmw_create_publisher(
     for sub_entity in &sub_entities {
         if let Some(endpoint) = hiroz::entity::entity_get_endpoint(sub_entity) {
             // Skip Ros2Dds endpoints that carry no node identity
-            let Some(node) = endpoint.node.as_ref() else {
+            if endpoint.node.is_none() {
                 continue;
-            };
+            }
 
             // node is Some here, so endpoint_gid is always Some
             let gid = hiroz::entity::endpoint_gid(endpoint).unwrap();
@@ -653,9 +653,9 @@ pub extern "C" fn rmw_create_subscription(
     for pub_entity in &pub_entities {
         if let Some(endpoint) = hiroz::entity::entity_get_endpoint(pub_entity) {
             // Skip Ros2Dds endpoints that carry no node identity
-            let Some(node) = endpoint.node.as_ref() else {
+            if endpoint.node.is_none() {
                 continue;
-            };
+            }
 
             // node is Some here, so endpoint_gid is always Some
             let gid = hiroz::entity::endpoint_gid(endpoint).unwrap();

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -268,7 +268,6 @@ pub extern "C" fn rmw_create_publisher(
         graph.get_entities_by_topic(hiroz::entity::EndpointKind::Subscription, &entity.topic);
 
     // Track which subscription GIDs we've already checked to avoid double-counting
-    let local_zid = graph.zid;
     let mut checked_gids = std::collections::HashSet::new();
     let mut incompatible_count = 0;
     let mut last_policy_kind = 0u32;
@@ -278,13 +277,6 @@ pub extern "C" fn rmw_create_publisher(
             let Some(node) = endpoint.node.as_ref() else {
                 continue;
             };
-
-            // DDS-style QoS-incompatibility checking is for remote peers --
-            // skip only this session's own entities. The old `!=` guard had
-            // this backwards: same-session only, never remote.
-            if node.z_id == local_zid {
-                continue;
-            }
 
             // node is Some here, so endpoint_gid is always Some
             let gid = hiroz::entity::endpoint_gid(endpoint).unwrap();
@@ -655,7 +647,6 @@ pub extern "C" fn rmw_create_subscription(
         graph.get_entities_by_topic(hiroz::entity::EndpointKind::Publisher, &entity.topic);
 
     // Track which publisher GIDs we've already checked to avoid double-counting
-    let local_zid = graph.zid;
     let mut checked_gids = std::collections::HashSet::new();
     let mut incompatible_count = 0;
     let mut last_policy_kind = 0u32;
@@ -665,13 +656,6 @@ pub extern "C" fn rmw_create_subscription(
             let Some(node) = endpoint.node.as_ref() else {
                 continue;
             };
-
-            // DDS-style QoS-incompatibility checking is for remote peers --
-            // skip only this session's own entities. The old `!=` guard had
-            // this backwards: same-session only, never remote.
-            if node.z_id == local_zid {
-                continue;
-            }
 
             // node is Some here, so endpoint_gid is always Some
             let gid = hiroz::entity::endpoint_gid(endpoint).unwrap();

--- a/crates/rmw-zenoh-rs/src/rmw.rs
+++ b/crates/rmw-zenoh-rs/src/rmw.rs
@@ -2005,31 +2005,7 @@ pub extern "C" fn rmw_get_publishers_info_by_topic(
             (*endpoint_info).endpoint_gid = gid_data;
 
             // Set QoS profile - convert from protocol QoS to hiroz QoS to rmw QoS
-            let hiroz_qos = hiroz::qos::QosProfile {
-                reliability: match endpoint.qos.reliability {
-                    hiroz_protocol::qos::QosReliability::Reliable => {
-                        hiroz::qos::QosReliability::Reliable
-                    }
-                    hiroz_protocol::qos::QosReliability::BestEffort => {
-                        hiroz::qos::QosReliability::BestEffort
-                    }
-                },
-                durability: match endpoint.qos.durability {
-                    hiroz_protocol::qos::QosDurability::TransientLocal => {
-                        hiroz::qos::QosDurability::TransientLocal
-                    }
-                    hiroz_protocol::qos::QosDurability::Volatile => {
-                        hiroz::qos::QosDurability::Volatile
-                    }
-                },
-                history: match endpoint.qos.history {
-                    hiroz_protocol::qos::QosHistory::KeepLast(depth) => {
-                        hiroz::qos::QosHistory::from_depth(depth)
-                    }
-                    hiroz_protocol::qos::QosHistory::KeepAll => hiroz::qos::QosHistory::KeepAll,
-                },
-                ..Default::default()
-            };
+            let hiroz_qos = crate::pubsub::protocol_qos_to_hiroz_qos(&endpoint.qos);
             (*endpoint_info).qos_profile = crate::qos::hiroz_qos_to_rmw_qos(&hiroz_qos);
         }
     }
@@ -3552,31 +3528,7 @@ pub extern "C" fn rmw_get_subscriptions_info_by_topic(
             (*endpoint_info).endpoint_gid = gid_data;
 
             // Set QoS profile - convert from protocol QoS to hiroz QoS to rmw QoS
-            let hiroz_qos = hiroz::qos::QosProfile {
-                reliability: match endpoint.qos.reliability {
-                    hiroz_protocol::qos::QosReliability::Reliable => {
-                        hiroz::qos::QosReliability::Reliable
-                    }
-                    hiroz_protocol::qos::QosReliability::BestEffort => {
-                        hiroz::qos::QosReliability::BestEffort
-                    }
-                },
-                durability: match endpoint.qos.durability {
-                    hiroz_protocol::qos::QosDurability::TransientLocal => {
-                        hiroz::qos::QosDurability::TransientLocal
-                    }
-                    hiroz_protocol::qos::QosDurability::Volatile => {
-                        hiroz::qos::QosDurability::Volatile
-                    }
-                },
-                history: match endpoint.qos.history {
-                    hiroz_protocol::qos::QosHistory::KeepLast(depth) => {
-                        hiroz::qos::QosHistory::from_depth(depth)
-                    }
-                    hiroz_protocol::qos::QosHistory::KeepAll => hiroz::qos::QosHistory::KeepAll,
-                },
-                ..Default::default()
-            };
+            let hiroz_qos = crate::pubsub::protocol_qos_to_hiroz_qos(&endpoint.qos);
             (*endpoint_info).qos_profile = crate::qos::hiroz_qos_to_rmw_qos(&hiroz_qos);
         }
     }


### PR DESCRIPTION
Two call sites in `rmw-zenoh-rs`'s QoS-incompatibility check only look at peers in the same Zenoh session (`if node.z_id != local_zid { continue; }`). They skip every other peer. `check_qos_compatibility_with_policy` implements full DDS-style matching (reliability, durability, deadline, liveliness), but a genuinely remote peer — the case this check exists for — never triggered it. Two endpoints in the same session could trigger it instead.

Related to [ZettaScaleLabs/hiroz#338](https://github.com/ZettaScaleLabs/hiroz/issues/338) (item 7), which amends [ZettaScaleLabs/hiroz#293](https://github.com/ZettaScaleLabs/hiroz/issues/293). #293 notes that hiroz raises `REQUESTED_QOS_INCOMPATIBLE`/`OFFERED_QOS_INCOMPATIBLE` where `rmw_zenoh_cpp` does not. This PR's finding is that the events were also firing for the wrong peers.

Depends on #347 (https://github.com/ZettaScaleLabs/hiroz/pull/347) — three of the four comparison rules compare against fields that PR gives real wire values. Before it, they compared against fabricated defaults.

## What this PR does

Removes both guards. Every discovered peer — same-session or remote — now reaches the QoS compatibility check. The two call sites are symmetric: publisher creation checks existing subscriptions, subscriber creation checks existing publishers.

## Why the guard is removed, not inverted

An earlier revision of this PR flipped the guard from `!=` to `==`. The reasoning was that a per-peer skip was harmless, because an aggregate event fires afterward anyway. That reasoning was wrong.

The guard sits inside the same loop that builds `incompatible_count`. Skipping same-session peers there removes them from the count itself. It does not just skip the per-peer `trigger_event_with_policy` call. A same-session pair with genuinely incompatible QoS then raised no event at all — neither per-peer nor aggregate. That is worse than the bug this PR set out to fix. It also does not match #338's own decision: apply DDS-style checking to all peers, not all peers except this session's own.

We checked whether a newly created entity could ever compare against itself. That would need a narrower guard instead of none. It cannot: each loop walks the opposite endpoint kind. Publisher creation walks subscriptions; subscriber creation walks publishers. So the new entity never appears in its own comparison set.

## Breaking changes

Behavioral: a peer with genuinely incompatible QoS now raises the incompatibility event, whether same-session or remote. Before, it matched silently in both cases. This only changes what the introspection and event APIs report; data flow is unaffected either way.

## Verification

Reviewed by reading. `rmw-zenoh-rs` cannot build in the available environment, because bindgen needs ROS headers this environment does not have. This environment did not compile or test the change directly. The project's GitHub CI does have ROS headers and verifies it there. No existing test relies on the old same-session-only filtering.
