### PR TITLE
perf(rmw-zenoh-rs): pin glibc trim threshold at init

### DIFF
--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -362,17 +362,38 @@ pub extern "C" fn rmw_init(
     // Stop glibc returning the payload heap to the kernel between messages.
     //
     // This RMW sizes its deserialisation buffer to the payload. glibc adapts
-    // M_MMAP_THRESHOLD to the largest mmap'd block a process frees and sets
-    // M_TRIM_THRESHOLD to twice it, so payload-sized buffers leave the trim
-    // threshold at roughly 4 MiB. An rclpy node's heap swings 6-9 MB per
-    // message at 1 MiB payloads, which exceeds that: the heap is handed back
-    // with brk on every free and re-faulted on the next message. Measured at
-    // 1 MiB / 200 Hz: 12,028 brk calls and 2.3M page faults in 18 s, costing
-    // 33% of round-trip latency and making the arm bimodal between runs.
+    // M_MMAP_THRESHOLD upward as it frees large blocks, and ties
+    // M_TRIM_THRESHOLD to twice that value. In our measurements, a process
+    // handling 1 MiB payloads settled with a trim threshold around 4 MiB --
+    // that is a measured figure for this workload, not a general glibc
+    // guarantee, and it depends on prior allocation history. An rclpy node's
+    // heap swings 6-9 MB per message at 1 MiB payloads, which exceeds that
+    // threshold: the heap is handed back with brk() on every free and
+    // re-faulted on the next message. Measured at 1 MiB / 200 Hz: 12,028 brk
+    // calls and 2.3M page faults in 18 s, costing 33% of round-trip latency
+    // and making the arm bimodal between runs.
     //
-    // An implementation that over-allocates avoids this by accident, because a
-    // larger freed block raises the threshold. Setting it explicitly is the
-    // same protection without the waste. See circle/hiroz issue 201.
+    // Both calls below are required together, not as a stronger/weaker pair.
+    // mallopt() on EITHER parameter disables glibc's automatic threshold
+    // adaptation for BOTH of them (see mallopt(3), "dynamic adjustment ...
+    // is disabled if any of M_TRIM_THRESHOLD, M_TOP_PAD, M_MMAP_THRESHOLD or
+    // M_MMAP_MAX is set"). Pinning M_TRIM_THRESHOLD alone freezes
+    // M_MMAP_THRESHOLD at its 128 KiB default, so every payload-sized buffer
+    // would then be served by mmap() instead of the heap -- measured to be
+    // *worse* than doing nothing at all, not merely ineffective. Raising
+    // M_MMAP_THRESHOLD in lockstep is what keeps the buffer heap-served, and
+    // M_TRIM_THRESHOLD is then what decides whether that heap is trimmed
+    // between messages.
+    //
+    // An implementation that over-allocates its buffer avoids this by
+    // accident, because freeing a larger block raises the threshold anyway.
+    // Setting it explicitly gives the same protection without the waste.
+    //
+    // 64 MiB is a bound, not a tuned value: it must exceed both the largest
+    // message this pins for and the working-set swing of several live
+    // payload-sized buffers, and it is (measured on this host) twice glibc's
+    // own ceiling on how far it will ever raise these thresholds by itself --
+    // so this pins inside the allocator's own envelope rather than past it.
     //
     // Deliberately skipped when the operator has set the glibc environment
     // variables, so an explicit deployment choice is not silently overridden.

--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -359,6 +359,44 @@ pub extern "C" fn rmw_init(
         }
     }
 
+    // Stop glibc returning the payload heap to the kernel between messages.
+    //
+    // This RMW sizes its deserialisation buffer to the payload. glibc adapts
+    // M_MMAP_THRESHOLD to the largest mmap'd block a process frees and sets
+    // M_TRIM_THRESHOLD to twice it, so payload-sized buffers leave the trim
+    // threshold at roughly 4 MiB. An rclpy node's heap swings 6-9 MB per
+    // message at 1 MiB payloads, which exceeds that: the heap is handed back
+    // with brk on every free and re-faulted on the next message. Measured at
+    // 1 MiB / 200 Hz: 12,028 brk calls and 2.3M page faults in 18 s, costing
+    // 33% of round-trip latency and making the arm bimodal between runs.
+    //
+    // An implementation that over-allocates avoids this by accident, because a
+    // larger freed block raises the threshold. Setting it explicitly is the
+    // same protection without the waste. See circle/hiroz issue 201.
+    //
+    // Deliberately skipped when the operator has set the glibc environment
+    // variables, so an explicit deployment choice is not silently overridden.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        const M_TRIM_THRESHOLD: core::ffi::c_int = -1;
+        const M_MMAP_THRESHOLD: core::ffi::c_int = -3;
+        unsafe extern "C" {
+            fn mallopt(param: core::ffi::c_int, value: core::ffi::c_int) -> core::ffi::c_int;
+        }
+        let operator_set = std::env::var_os("MALLOC_TRIM_THRESHOLD_").is_some()
+            || std::env::var_os("MALLOC_MMAP_THRESHOLD_").is_some();
+        if !operator_set {
+            // 64 MiB clears the measured 6-9 MB working-set swing with margin.
+            const THRESHOLD: core::ffi::c_int = 64 << 20;
+            let mmap_rc = unsafe { mallopt(M_MMAP_THRESHOLD, THRESHOLD) };
+            let trim_rc = unsafe { mallopt(M_TRIM_THRESHOLD, THRESHOLD) };
+            tracing::debug!(
+                "glibc thresholds pinned at {} MiB (mallopt rc: mmap={}, trim={})",
+                THRESHOLD >> 20, mmap_rc, trim_rc
+            );
+        }
+    }
+
     // Initialize Zenoh logging
     zenoh::init_log_from_env_or("error");
 

--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -411,10 +411,23 @@ pub extern "C" fn rmw_init(
             const THRESHOLD: core::ffi::c_int = 64 << 20;
             let mmap_rc = unsafe { mallopt(M_MMAP_THRESHOLD, THRESHOLD) };
             let trim_rc = unsafe { mallopt(M_TRIM_THRESHOLD, THRESHOLD) };
-            tracing::debug!(
-                "glibc thresholds pinned at {} MiB (mallopt rc: mmap={}, trim={})",
-                THRESHOLD >> 20, mmap_rc, trim_rc
-            );
+            if mmap_rc == 0 || trim_rc == 0 {
+                // mallopt() returns 0 only for a handful of documented invalid
+                // (param, value) combinations; the cfg gate above and the
+                // fixed, valid THRESHOLD constant make this unlikely, but a
+                // silent failure here would look identical to the regression
+                // this call exists to prevent, so make it visible by default.
+                tracing::warn!(
+                    "glibc rejected the allocator threshold pin (mallopt rc: mmap={}, trim={}); \
+                     large 1 MiB-class messages may show the heap-trim latency regression this call exists to avoid",
+                    mmap_rc, trim_rc
+                );
+            } else {
+                tracing::debug!(
+                    "glibc thresholds pinned at {} MiB (mallopt rc: mmap={}, trim={})",
+                    THRESHOLD >> 20, mmap_rc, trim_rc
+                );
+            }
         }
     }
 

--- a/crates/rmw-zenoh-rs/src/context.rs
+++ b/crates/rmw-zenoh-rs/src/context.rs
@@ -359,6 +359,9 @@ pub extern "C" fn rmw_init(
         }
     }
 
+    // Initialize Zenoh logging
+    zenoh::init_log_from_env_or("error");
+
     // Stop glibc returning the payload heap to the kernel between messages.
     //
     // This RMW sizes its deserialisation buffer to the payload. glibc adapts
@@ -391,9 +394,16 @@ pub extern "C" fn rmw_init(
     //
     // 64 MiB is a bound, not a tuned value: it must exceed both the largest
     // message this pins for and the working-set swing of several live
-    // payload-sized buffers, and it is (measured on this host) twice glibc's
-    // own ceiling on how far it will ever raise these thresholds by itself --
-    // so this pins inside the allocator's own envelope rather than past it.
+    // payload-sized buffers. It is NOT "inside glibc's own envelope" for
+    // both parameters equally, and the two should not be read as matching
+    // the same ceiling: glibc's *dynamic* M_MMAP_THRESHOLD adjustment caps
+    // itself at DEFAULT_MMAP_THRESHOLD_MAX (typically 32 MiB on 64-bit), so
+    // pinning M_MMAP_THRESHOLD to 64 MiB is deliberately larger than glibc's
+    // own adjustment would ever choose for that parameter -- an explicit
+    // override, not a value glibc would arrive at on its own. M_TRIM_THRESHOLD
+    // is different: glibc ties its dynamic value to twice the mmap threshold,
+    // so 64 MiB is exactly the largest value its own adjustment could ever
+    // reach for THIS parameter.
     //
     // Deliberately skipped when the operator has set the glibc environment
     // variables, so an explicit deployment choice is not silently overridden.
@@ -430,9 +440,6 @@ pub extern "C" fn rmw_init(
             }
         }
     }
-
-    // Initialize Zenoh logging
-    zenoh::init_log_from_env_or("error");
 
     // Log RMW initialization
     tracing::info!("rmw_zenoh_rs v{} initialized", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary

`rmw_zenoh_rs` allocates a fresh payload buffer per message. At 1 MiB this leaves glibc's heap-trim threshold below the process's working set. glibc hands the heap back with `brk`, and the next message re-faults it. This costs 33% of round-trip latency. It also makes the cell bimodal between runs. Fixes #349.

## Key Changes

This PR adds two `mallopt` calls at `rmw_init`. They pin `M_MMAP_THRESHOLD` and `M_TRIM_THRESHOLD` to 64 MiB. This fix skips both calls when the operator has already set the corresponding `MALLOC_*` environment variables.

This fix needs both calls together. `mallopt` on either threshold disables glibc's dynamic adjustment of both of them. Pinning one alone leaves the other frozen at its 128 KiB default. That measures worse than not touching either threshold (see #349 for the lever-separation data).

This PR checks `mallopt`'s return code. On failure, it logs at `warn`. On success, it logs at `debug`. Otherwise, a silently-rejected pin would look identical to the fix simply not applying.

## What fails without this

No test goes red. This is a performance defect. The failing baseline is the measurement in #349: 4700 us vs 3137 us at 1 MiB / 200 Hz, against the pinned-environment-variable target. The rep-to-rep spread falls from 45% to 6% against that same target. This PR's change reproduces that target without requiring the operator to set anything.

## Test coverage

None added. No existing test exercises `rmw_init`, with or without this change. That gap pre-dates this PR.

A meaningful test of the core effect would need to assert glibc's internal allocator state. That is not practical from a Rust unit test. The opt-out logic is testable in principle: it skips the pin when `MALLOC_*` is already set. But that logic is currently inlined in `rmw_init`, not factored into a separate function. So this PR adds no test for it.

This PR states the gap explicitly. A green CI run does not imply behavioural coverage that does not exist.

## Breaking Changes

None functionally. Disclosed for completeness: this change sets glibc allocator policy for the whole process, not just for this crate's own allocations. It skips doing so if the operator has already set `MALLOC_TRIM_THRESHOLD_` or `MALLOC_MMAP_THRESHOLD_`. An explicit deployment choice is never overridden.
